### PR TITLE
Update backend setup for pip

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,11 +1,13 @@
 # Backend Setup
 
-This backend uses **FastAPI** with the async Neo4j driver. Install dependencies via Poetry:
+This backend uses **FastAPI** with the async Neo4j driver. Install dependencies via pip:
 
 ```bash
 cd backend
-poetry install
-poetry run uvicorn app.main:app --reload
+pip install -r requirements.txt
+uvicorn app.main:app --reload
 ```
 
 By default the app expects a local Neo4j instance reachable at `bolt://localhost:7687` with user/password `neo4j`. Set `NEO4J_URI`, `NEO4J_USER`, and `NEO4J_PASSWORD` to override.
+
+The `pyproject.toml` file is kept only for reference and is not used by these instructions.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.111
+uvicorn[standard]==0.29
+neo4j==5.16
+pydantic==2.7
+pytest==8.2


### PR DESCRIPTION
## Summary
- add backend/requirements.txt with pinned package versions
- update backend instructions to use pip instead of Poetry
- note that `pyproject.toml` is unused

## Testing
- `pytest -q`