### PR TITLE
Add dev server proxy configuration

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -8,4 +8,6 @@ npm install
 npm run dev
 ```
 
-On start it connects to the backend at the same host and loads project 1.
+The development server proxies API requests to `http://localhost:8000`, so make
+sure the backend is running on that port before starting the frontend. On start
+it connects to the backend at the same host and loads project 1.

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,4 +3,9 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/': { target: 'http://localhost:8000', changeOrigin: true, ws: true }
+    }
+  }
 })


### PR DESCRIPTION
## Summary
- proxy all frontend paths to port 8000
- note proxy behaviour in frontend README

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_684144e4542c8328994976021bfcde4e