### PR TITLE
Fix dev server proxy to expose front-end

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -8,6 +8,7 @@ npm install
 npm run dev
 ```
 
-The development server proxies API requests to `http://localhost:8000`, so make
-sure the backend is running on that port before starting the frontend. On start
-it connects to the backend at the same host and loads project 1.
+The development server proxies API requests starting with `/projects`, `/materials`,
+`/nodes`, `/relations`, `/score` and `/ws` to `http://localhost:8000`. Make sure
+the backend is running on that port before starting the frontend. On start it
+connects to the backend at the same host and loads project 1.

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,7 +5,12 @@ export default defineConfig({
   plugins: [react()],
   server: {
     proxy: {
-      '/': { target: 'http://localhost:8000', changeOrigin: true, ws: true }
+      '/projects': { target: 'http://localhost:8000', changeOrigin: true },
+      '/materials': { target: 'http://localhost:8000', changeOrigin: true },
+      '/nodes': { target: 'http://localhost:8000', changeOrigin: true },
+      '/relations': { target: 'http://localhost:8000', changeOrigin: true },
+      '/score': { target: 'http://localhost:8000', changeOrigin: true },
+      '/ws': { target: 'ws://localhost:8000', ws: true }
     }
   }
 })


### PR DESCRIPTION
## Summary
- narrow the Vite development proxy to only backend API routes
- document the API path proxying

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6841529757a4832881d1b6b5c0c24cbd