### PR TITLE
Improve frontend error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ npm run dev
 ```
 
 With both processes running the application is reachable at [http://localhost:5173](http://localhost:5173) and talks to the API on port 8000.
+If the initial API request fails (for example due to a 404 or connection issue),
+the frontend shows an error message instead of the editor.
 
 ### Configuration
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -11,4 +11,5 @@ npm run dev
 The development server proxies API requests starting with `/projects`, `/materials`,
 `/nodes`, `/relations`, `/score` and `/ws` to `http://localhost:8000`. Make sure
 the backend is running on that port before starting the frontend. On start it
-connects to the backend at the same host and loads project 1.
+connects to the backend at the same host and loads project 1. When this request
+fails, the app displays an error message to help with troubleshooting.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,11 +6,18 @@ import useUndoRedo from './components/useUndoRedo'
 export default function App() {
   const [data, setData] = useState({ nodes: [], edges: [], materials: [] })
   const { state, setState, undo, redo } = useUndoRedo(data, 50)
+  const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     fetch('/projects/1/graph')
-      .then(r => r.json())
+      .then(r => {
+        if (!r.ok) {
+          throw new Error(`HTTP ${r.status}`)
+        }
+        return r.json()
+      })
       .then(setState)
+      .catch(() => setError('Failed to load project data'))
   }, [])
 
   useEffect(() => {
@@ -21,6 +28,10 @@ export default function App() {
     }
     return () => ws.close()
   }, [setState])
+
+  if (error) {
+    return <div className="p-4 text-red-600">{error}</div>
+  }
 
   return (
     <div className="flex h-full">


### PR DESCRIPTION
## Summary
- handle HTTP errors when fetching the graph in `App.tsx`
- display a simple error message on failure
- document new error handling behavior

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_68415c2a13548328bff982c785d4c11e