### PR TITLE
Fix React Table initialization

### DIFF
--- a/frontend/src/components/MaterialTable.tsx
+++ b/frontend/src/components/MaterialTable.tsx
@@ -1,5 +1,10 @@
 import React from 'react'
-import { useReactTable, createColumnHelper, flexRender } from '@tanstack/react-table'
+import {
+  useReactTable,
+  createColumnHelper,
+  flexRender,
+  getCoreRowModel,
+} from '@tanstack/react-table'
 
 interface Material {
   id: number
@@ -26,7 +31,11 @@ export default function MaterialTable({ materials, onDelete }: Props) {
     }),
   ]
 
-  const table = useReactTable({ data: materials, columns })
+  const table = useReactTable({
+    data: materials,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  })
 
   return (
     <table className="min-w-full text-sm">


### PR DESCRIPTION
## Summary
- add `getCoreRowModel` usage to MaterialTable so React Table works

## Testing
- `npm install` *(fails: No matching version found for react-flow-renderer@^11.8.5)*

------
https://chatgpt.com/codex/tasks/task_b_68417769b91883289d67cc86a7b4e6b0