### PR TITLE
Update ReactFlow version info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Circular Design Toolkit
 
 This repository contains a minimal FastAPI backend and a React\+Vite frontend used to model material flows.
+The frontend relies on **ReactFlow v11** for the graph editor. Components using ReactFlow must import `reactflow/dist/style.css` to include its default styles.
 
 ## Requirements
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,6 +1,8 @@
 # Frontend Setup
 
 This React app uses Vite and Tailwind CSS.
+It renders flows using **ReactFlow v11**.
+Remember to import `reactflow/dist/style.css` in components that use ReactFlow.
 
 ```bash
 cd frontend


### PR DESCRIPTION
## Summary
- update README to mention ReactFlow v11 and importing CSS
- add same note to frontend README

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_68417e493a6c8328bee9eaafa3b8a8dd