### PR TITLE
Fix quick-start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,13 @@ The frontend currently expects that a project with ID `1` exists. You can create
 it via the API using `curl`:
 
 ```bash
-curl -X POST http://localhost:8000/projects -H 'Content-Type: application/json' \
+curl -X POST http://localhost:8000/projects/ \
+  -H 'Content-Type: application/json' \
   -d '{"name": "My Project"}'
 ```
+
+Note the trailing slash in `/projects/`. Omitting it triggers a redirect that
+causes a `405 Method Not Allowed` error.
 
 ### Configuration
 


### PR DESCRIPTION
## Summary
- correct the REST endpoint in the README example
- explain why the trailing slash is required

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684182fb14a48328ae3a9f210f15b9a6