### PR TITLE
Update default Neo4j password

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -11,7 +11,7 @@ def get_driver(uri: str, user: str | None = None, password: str | None = None):
 driver = get_driver(
     uri=os.getenv("NEO4J_URI", "bolt://localhost:7687"),
     user=os.getenv("NEO4J_USER", "neo4j"),
-    password=os.getenv("NEO4J_PASSWORD", "your_password"),
+    password=os.getenv("NEO4J_PASSWORD", "neo4j"),
 )
 
 


### PR DESCRIPTION
## Summary
- adjust default Neo4j credentials to use `neo4j` as password

## Testing
- `python -m py_compile backend/app/database.py`
- `pytest -q`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_6841900cd1808328b5fe16c9c187e2aa