### PR TITLE
Fix GraphCanvas height

### DIFF
--- a/frontend/src/components/GraphCanvas.tsx
+++ b/frontend/src/components/GraphCanvas.tsx
@@ -12,7 +12,7 @@ interface Props {
 export default function GraphCanvas({ nodes, edges, onChange }: Props) {
   const onConnect = (params: any) => onChange({ nodes, edges: addEdge(params, edges) })
   return (
-    <ReactFlow nodes={nodes} edges={edges} onConnect={onConnect} fitView className="h-5/6">
+    <ReactFlow nodes={nodes} edges={edges} onConnect={onConnect} fitView className="h-full">
       <MiniMap />
       <Controls />
       <Background />


### PR DESCRIPTION
## Summary
- use full height for GraphCanvas container
- confirm parent containers use explicit height

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_684192e3a6d483289e6b6610b84bd783