### PR TITLE
Improve Neo4j error handling

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,7 +1,8 @@
 from typing import AsyncGenerator
 import os
+import asyncio
 
-from neo4j import AsyncGraphDatabase, AsyncSession
+from neo4j import AsyncGraphDatabase, AsyncSession, exceptions
 
 
 def get_driver(uri: str, user: str | None = None, password: str | None = None):
@@ -13,6 +14,11 @@ driver = get_driver(
     user=os.getenv("NEO4J_USER", "neo4j"),
     password=os.getenv("NEO4J_PASSWORD", "neo4j"),
 )
+
+try:
+    asyncio.run(driver.verify_connectivity())
+except exceptions.ServiceUnavailable as exc:
+    raise RuntimeError("Unable to connect to Neo4j") from exc
 
 
 async def get_session(*, write: bool = False) -> AsyncGenerator[AsyncSession, None]:

--- a/backend/app/routers/materials.py
+++ b/backend/app/routers/materials.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Depends, HTTPException
-from neo4j import AsyncSession
+from neo4j import AsyncSession, exceptions
 
 from .websocket import broadcast
 from ..database import get_session
@@ -11,7 +11,10 @@ router = APIRouter(prefix="/materials", tags=["materials"])
 @router.post("/", response_model=Material)
 async def create_material(material: MaterialCreate, session: AsyncSession = Depends(get_session)):
     query = """CREATE (m:Material {name: $name, weight: $weight}) RETURN id(m) AS id, m.name AS name, m.weight AS weight"""
-    result = await session.run(query, name=material.name, weight=material.weight)
+    try:
+        result = await session.run(query, name=material.name, weight=material.weight)
+    except exceptions.ServiceUnavailable:
+        raise HTTPException(status_code=503, detail="Neo4j unavailable")
     record = await result.single()
     await broadcast(0, {"op": "create_material", "id": record["id"]})
     return Material(id=record["id"], name=record["name"], weight=record["weight"])
@@ -20,7 +23,10 @@ async def create_material(material: MaterialCreate, session: AsyncSession = Depe
 @router.get("/{material_id}", response_model=Material)
 async def get_material(material_id: int, session: AsyncSession = Depends(get_session)):
     query = "MATCH (m:Material) WHERE id(m)=$id RETURN id(m) AS id, m.name AS name, m.weight AS weight"
-    result = await session.run(query, id=material_id)
+    try:
+        result = await session.run(query, id=material_id)
+    except exceptions.ServiceUnavailable:
+        raise HTTPException(status_code=503, detail="Neo4j unavailable")
     record = await result.single()
     if not record:
         raise HTTPException(status_code=404, detail="Material not found")
@@ -29,6 +35,9 @@ async def get_material(material_id: int, session: AsyncSession = Depends(get_ses
 
 @router.delete("/{material_id}")
 async def delete_material(material_id: int, session: AsyncSession = Depends(get_session)):
-    await session.run("MATCH (m:Material) WHERE id(m)=$id DETACH DELETE m", id=material_id)
+    try:
+        await session.run("MATCH (m:Material) WHERE id(m)=$id DETACH DELETE m", id=material_id)
+    except exceptions.ServiceUnavailable:
+        raise HTTPException(status_code=503, detail="Neo4j unavailable")
     await broadcast(0, {"op": "delete_material", "id": material_id})
     return {"ok": True}

--- a/backend/app/routers/nodes.py
+++ b/backend/app/routers/nodes.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Depends, HTTPException
-from neo4j import AsyncSession
+from neo4j import AsyncSession, exceptions
 
 from .websocket import broadcast
 from ..database import get_session
@@ -14,7 +14,10 @@ async def create_node(node: NodeCreate, session: AsyncSession = Depends(get_sess
         """MATCH (p:Project) WHERE id(p)=$pid MATCH (m:Material) WHERE id(m)=$mid """
         "CREATE (n:Node {level: $level})-[:USES]->(m)-[:PART_OF]->(p) RETURN id(n) AS id"
     )
-    result = await session.run(query, pid=node.project_id, mid=node.material_id, level=node.level)
+    try:
+        result = await session.run(query, pid=node.project_id, mid=node.material_id, level=node.level)
+    except exceptions.ServiceUnavailable:
+        raise HTTPException(status_code=503, detail="Neo4j unavailable")
     record = await result.single()
     await broadcast(node.project_id, {"op": "create_node", "id": record["id"]})
     return Node(id=record["id"], project_id=node.project_id, material_id=node.material_id, level=node.level)
@@ -27,7 +30,10 @@ async def get_node(node_id: int, session: AsyncSession = Depends(get_session)):
         "MATCH (n)-[:PART_OF]->(p:Project) "
         "RETURN id(n) AS id, id(p) AS project_id, id(m) AS material_id, n.level AS level"
     )
-    result = await session.run(query, id=node_id)
+    try:
+        result = await session.run(query, id=node_id)
+    except exceptions.ServiceUnavailable:
+        raise HTTPException(status_code=503, detail="Neo4j unavailable")
     record = await result.single()
     if not record:
         raise HTTPException(status_code=404, detail="Node not found")
@@ -36,9 +42,15 @@ async def get_node(node_id: int, session: AsyncSession = Depends(get_session)):
 
 @router.delete("/{node_id}")
 async def delete_node(node_id: int, session: AsyncSession = Depends(get_session)):
-    result = await session.run("MATCH (n:Node)-[:PART_OF]->(p) WHERE id(n)=$id RETURN id(p) AS pid", id=node_id)
+    try:
+        result = await session.run("MATCH (n:Node)-[:PART_OF]->(p) WHERE id(n)=$id RETURN id(p) AS pid", id=node_id)
+    except exceptions.ServiceUnavailable:
+        raise HTTPException(status_code=503, detail="Neo4j unavailable")
     rec = await result.single()
     pid = rec["pid"] if rec else 0
-    await session.run("MATCH (n:Node) WHERE id(n)=$id DETACH DELETE n", id=node_id)
+    try:
+        await session.run("MATCH (n:Node) WHERE id(n)=$id DETACH DELETE n", id=node_id)
+    except exceptions.ServiceUnavailable:
+        raise HTTPException(status_code=503, detail="Neo4j unavailable")
     await broadcast(pid, {"op": "delete_node", "id": node_id})
     return {"ok": True}

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Depends, HTTPException
-from neo4j import AsyncSession
+from neo4j import AsyncSession, exceptions
 
 from .websocket import broadcast
 from ..database import get_session
@@ -11,7 +11,10 @@ router = APIRouter(prefix="/projects", tags=["projects"])
 @router.post("/", response_model=Project)
 async def create_project(project: ProjectCreate, session: AsyncSession = Depends(get_session)):
     query = """CREATE (p:Project {name: $name}) RETURN id(p) AS id, p.name AS name"""
-    result = await session.run(query, name=project.name)
+    try:
+        result = await session.run(query, name=project.name)
+    except exceptions.ServiceUnavailable:
+        raise HTTPException(status_code=503, detail="Neo4j unavailable")
     record = await result.single()
     await broadcast(record["id"], {"op": "create_project", "id": record["id"]})
     return Project(id=record["id"], name=record["name"])
@@ -20,7 +23,10 @@ async def create_project(project: ProjectCreate, session: AsyncSession = Depends
 @router.get("/{project_id}", response_model=Project)
 async def get_project(project_id: int, session: AsyncSession = Depends(get_session)):
     query = "MATCH (p:Project) WHERE id(p)=$id RETURN id(p) AS id, p.name AS name"
-    result = await session.run(query, id=project_id)
+    try:
+        result = await session.run(query, id=project_id)
+    except exceptions.ServiceUnavailable:
+        raise HTTPException(status_code=503, detail="Neo4j unavailable")
     record = await result.single()
     if not record:
         raise HTTPException(status_code=404, detail="Project not found")
@@ -30,12 +36,21 @@ async def get_project(project_id: int, session: AsyncSession = Depends(get_sessi
 @router.get("/{project_id}/graph")
 async def get_graph(project_id: int, session: AsyncSession = Depends(get_session)):
     q_nodes = "MATCH (p:Project)<-[:PART_OF]-(n:Node)-[:USES]->(m:Material) WHERE id(p)=$pid RETURN id(n) AS id, id(m) AS material_id, n.level AS level"
-    result = await session.run(q_nodes, pid=project_id)
+    try:
+        result = await session.run(q_nodes, pid=project_id)
+    except exceptions.ServiceUnavailable:
+        raise HTTPException(status_code=503, detail="Neo4j unavailable")
     nodes = [dict(record) for record in await result.to_list()]
     q_edges = "MATCH (p:Project)<-[:PART_OF]-(s:Node)-[r:LINK]->(t:Node) WHERE id(p)=$pid RETURN id(r) AS id, id(s) AS source, id(t) AS target"
-    res_e = await session.run(q_edges, pid=project_id)
+    try:
+        res_e = await session.run(q_edges, pid=project_id)
+    except exceptions.ServiceUnavailable:
+        raise HTTPException(status_code=503, detail="Neo4j unavailable")
     edges = [dict(record) for record in await res_e.to_list()]
     q_mats = "MATCH (m:Material) RETURN id(m) AS id, m.name AS name, m.weight AS weight"
-    res_m = await session.run(q_mats)
+    try:
+        res_m = await session.run(q_mats)
+    except exceptions.ServiceUnavailable:
+        raise HTTPException(status_code=503, detail="Neo4j unavailable")
     materials = [dict(record) for record in await res_m.to_list()]
     return {"nodes": nodes, "edges": edges, "materials": materials}


### PR DESCRIPTION
## Summary
- verify Neo4j connectivity during startup
- provide fallback HTTP 503 responses when Neo4j is unreachable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684192c14e2c8328b98a428b224d14ab