### PR TITLE
Add env var examples for Neo4j

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Example configuration for Neo4j connection
+NEO4J_URI=bolt://localhost:7687
+NEO4J_USER=neo4j
+NEO4J_PASSWORD=your_password

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ cd backend
 python -m venv venv
 source venv/bin/activate  # on Windows use "venv\\Scripts\\activate"
 pip install -r requirements.txt
-python -m uvicorn app.main:app --reload
+NEO4J_PASSWORD=your_password uvicorn app.main:app --reload
 ```
 
 ### 2. Start the frontend

--- a/backend/README.md
+++ b/backend/README.md
@@ -5,7 +5,7 @@ This backend uses **FastAPI** with the async Neo4j driver. Install dependencies 
 ```bash
 cd backend
 pip install -r requirements.txt
-uvicorn app.main:app --reload
+NEO4J_PASSWORD=your_password uvicorn app.main:app --reload
 ```
 
 By default the app expects a local Neo4j instance reachable at `bolt://localhost:7687` with user/password `neo4j`. Set `NEO4J_URI`, `NEO4J_USER`, and `NEO4J_PASSWORD` to override.


### PR DESCRIPTION
## Summary
- show how to pass `NEO4J_PASSWORD` when starting the backend
- provide `.env.example` with all Neo4j variables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684193cfef988328a06be763c86888f2