### PR TITLE
Add Neo4j startup verification

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,8 +1,15 @@
 from fastapi import FastAPI
 
+from .database import verify_connectivity
+
 from .routers import projects, materials, nodes, relations, score, websocket
 
 app = FastAPI(title="Circular Design Toolkit")
+
+
+@app.on_event("startup")
+async def startup() -> None:
+    await verify_connectivity()
 
 app.include_router(projects.router)
 app.include_router(materials.router)

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,6 +1,5 @@
 from typing import AsyncGenerator
 import os
-import asyncio
 
 from neo4j import AsyncGraphDatabase, AsyncSession, exceptions
 
@@ -15,10 +14,12 @@ driver = get_driver(
     password=os.getenv("NEO4J_PASSWORD", "neo4j"),
 )
 
-try:
-    asyncio.run(driver.verify_connectivity())
-except exceptions.ServiceUnavailable as exc:
-    raise RuntimeError("Unable to connect to Neo4j") from exc
+async def verify_connectivity() -> None:
+    """Ensure the Neo4j database is reachable."""
+    try:
+        await driver.verify_connectivity()
+    except exceptions.ServiceUnavailable as exc:
+        raise RuntimeError("Unable to connect to Neo4j") from exc
 
 
 async def get_session(*, write: bool = False) -> AsyncGenerator[AsyncSession, None]:


### PR DESCRIPTION
## Summary
- check connectivity to Neo4j using a FastAPI startup event
- expose a helper `verify_connectivity` for startup validation

## Testing
- `python -m pip install -r backend/requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_684193d48b7c8328a6803b06ccc00f72