### PR TITLE
Clarify Neo4j env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+NEO4J_URI=bolt://localhost:7687
+NEO4J_USER=neo4j
+NEO4J_PASSWORD=neo4j

--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ The frontend relies on **ReactFlow v11** for the graph editor. Components using 
 
 - Python 3.11 or newer
 - Node.js 18 or newer
-- A running Neo4j instance (defaults to `bolt://localhost:7687` with user `neo4j`/`neo4j`)
+- A running Neo4j instance (defaults to `bolt://localhost:7687` with user `neo4j`/`neo4j`).
+  API requests will fail unless Neo4j runs with these credentials or the
+  environment variables `NEO4J_URI`, `NEO4J_USER` and `NEO4J_PASSWORD` are set
+  accordingly.
 
 ## Quick start
 
@@ -54,7 +57,9 @@ causes a `405 Method Not Allowed` error.
 
 ### Configuration
 
-If your Neo4j database is not running locally use the environment variables `NEO4J_URI`, `NEO4J_USER` and `NEO4J_PASSWORD` to override the defaults.
+If your Neo4j database is not running locally use the environment variables
+`NEO4J_URI`, `NEO4J_USER` and `NEO4J_PASSWORD` to override the defaults;
+otherwise all API requests will fail.
 
 ### Building for production
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -8,6 +8,10 @@ pip install -r requirements.txt
 uvicorn app.main:app --reload
 ```
 
-By default the app expects a local Neo4j instance reachable at `bolt://localhost:7687` with user/password `neo4j`. Set `NEO4J_URI`, `NEO4J_USER`, and `NEO4J_PASSWORD` to override.
+By default the app expects a local Neo4j instance reachable at
+`bolt://localhost:7687` with user/password `neo4j`.
+API requests will fail unless Neo4j runs with these credentials or you set the
+environment variables `NEO4J_URI`, `NEO4J_USER` and `NEO4J_PASSWORD` to match
+your database. You can copy `.env.example` to `.env` to define them.
 
 The `pyproject.toml` file is kept only for reference and is not used by these instructions.


### PR DESCRIPTION
## Summary
- document that the backend requires Neo4j credentials
- clarify configuration section of main README
- add example `.env` file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684192e24c188328bc6fd19d6e624b12