### PR TITLE
Update default Neo4j credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The frontend relies on **ReactFlow v11** for the graph editor. Components using 
 
 - Python 3.11 or newer
 - Node.js 18 or newer
-- A running Neo4j instance (defaults to `bolt://localhost:7687` with user `neo4j`/`neo4j`)
+- A running Neo4j instance (defaults to `bolt://localhost:7687` with user `neo4j`/`your_password`)
 
 ## Quick start
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -8,6 +8,6 @@ pip install -r requirements.txt
 NEO4J_PASSWORD=your_password uvicorn app.main:app --reload
 ```
 
-By default the app expects a local Neo4j instance reachable at `bolt://localhost:7687` with user/password `neo4j`. Set `NEO4J_URI`, `NEO4J_USER`, and `NEO4J_PASSWORD` to override.
+By default the app expects a local Neo4j instance reachable at `bolt://localhost:7687` with user/password `neo4j/your_password`. Set `NEO4J_URI`, `NEO4J_USER`, and `NEO4J_PASSWORD` to override.
 
 The `pyproject.toml` file is kept only for reference and is not used by these instructions.


### PR DESCRIPTION
## Summary
- fix the default Neo4j password in the root README
- update backend README to mention the same default password

## Testing
- `grep -R "your_password" -n | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68492fe6fdd483329a2726cfc329b6f3