### PR TITLE
Add router tests and update backend docs

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -11,3 +11,13 @@ NEO4J_PASSWORD=your_password uvicorn app.main:app --reload
 By default the app expects a local Neo4j instance reachable at `bolt://localhost:7687` with user/password `neo4j`. Set `NEO4J_URI`, `NEO4J_USER`, and `NEO4J_PASSWORD` to override.
 
 The `pyproject.toml` file is kept only for reference and is not used by these instructions.
+
+
+## Running tests
+
+The `tests/` directory contains pytest-based tests. They use a mocked Neo4j session so no database is required. Ensure the requirements are installed and run the tests from within `backend`:
+
+```bash
+cd backend
+pytest
+```

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,5 @@ uvicorn[standard]==0.29
 neo4j==5.16
 pydantic==2.7
 pytest==8.2
+
+httpx==0.27

--- a/backend/tests/test_projects.py
+++ b/backend/tests/test_projects.py
@@ -1,0 +1,30 @@
+from fastapi.testclient import TestClient
+
+from app import app
+from app.database import get_session
+
+
+class FakeResult:
+    def __init__(self, record):
+        self._record = record
+
+    async def single(self):
+        return self._record
+
+
+class FakeSession:
+    async def run(self, query, **params):
+        return FakeResult({"id": 1, "name": params["name"]})
+
+
+async def override_get_session():
+    yield FakeSession()
+
+
+def test_create_project():
+    app.dependency_overrides[get_session] = override_get_session
+    client = TestClient(app)
+    response = client.post("/projects/", json={"name": "Demo"})
+    assert response.status_code == 200
+    assert response.json() == {"id": 1, "name": "Demo"}
+    app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- add tests directory with project router test
- require `httpx` for testing
- document how to run tests in backend README

## Testing
- `ruff check backend`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68493072899c83329ffab4cf9130088b