### PR TITLE
Refactor graph retrieval to use Result.data()

### DIFF
--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -42,17 +42,17 @@ async def get_graph(project_id: int, session: AsyncSession = Depends(get_session
         result = await session.run(q_nodes, pid=project_id)
     except exceptions.ServiceUnavailable:
         raise HTTPException(status_code=503, detail="Neo4j unavailable")
-    nodes = [dict(record) for record in await result.to_list()]
+    nodes = await result.data()
     q_edges = "MATCH (p:Project)<-[:PART_OF]-(s:Node)-[r:LINK]->(t:Node) WHERE id(p)=$pid RETURN id(r) AS id, id(s) AS source, id(t) AS target"
     try:
         res_e = await session.run(q_edges, pid=project_id)
     except exceptions.ServiceUnavailable:
         raise HTTPException(status_code=503, detail="Neo4j unavailable")
-    edges = [dict(record) for record in await res_e.to_list()]
+    edges = await res_e.data()
     q_mats = "MATCH (m:Material) RETURN id(m) AS id, m.name AS name, m.weight AS weight"
     try:
         res_m = await session.run(q_mats)
     except exceptions.ServiceUnavailable:
         raise HTTPException(status_code=503, detail="Neo4j unavailable")
-    materials = [dict(record) for record in await res_m.to_list()]
+    materials = await res_m.data()
     return {"nodes": nodes, "edges": edges, "materials": materials}

--- a/backend/tests/test_projects.py
+++ b/backend/tests/test_projects.py
@@ -17,8 +17,40 @@ class FakeSession:
         return FakeResult({"id": 1, "name": params["name"]})
 
 
+class FakeResultList:
+    def __init__(self, data_list):
+        self._data_list = data_list
+
+    async def data(self):
+        return self._data_list
+
+
+class FakeSessionGraph:
+    def __init__(self):
+        self._calls = 0
+
+    async def run(self, query, **params):
+        self._calls += 1
+        if self._calls == 1:
+            return FakeResultList([
+                {"id": 1, "material_id": 2, "level": 0}
+            ])
+        elif self._calls == 2:
+            return FakeResultList([
+                {"id": 10, "source": 1, "target": 2}
+            ])
+        else:
+            return FakeResultList([
+                {"id": 2, "name": "Steel", "weight": 7.8}
+            ])
+
+
 async def override_get_session():
     yield FakeSession()
+
+
+async def override_get_session_graph():
+    yield FakeSessionGraph()
 
 
 def test_create_project():
@@ -27,4 +59,17 @@ def test_create_project():
     response = client.post("/projects/", json={"name": "Demo"})
     assert response.status_code == 200
     assert response.json() == {"id": 1, "name": "Demo"}
+    app.dependency_overrides.clear()
+
+
+def test_get_graph():
+    app.dependency_overrides[get_session] = override_get_session_graph
+    client = TestClient(app)
+    response = client.get("/projects/1/graph")
+    assert response.status_code == 200
+    assert response.json() == {
+        "nodes": [{"id": 1, "material_id": 2, "level": 0}],
+        "edges": [{"id": 10, "source": 1, "target": 2}],
+        "materials": [{"id": 2, "name": "Steel", "weight": 7.8}],
+    }
     app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- refactor `get_graph` endpoint to use `Result.data()` instead of `to_list()`
- simplify list conversions
- add unit test for `get_graph` using a fake session

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684937df70588328816216a3906d785d