### PR TITLE
Fix write access errors in Neo4j routes

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -27,3 +27,8 @@ async def get_session(*, write: bool = False) -> AsyncGenerator[AsyncSession, No
         default_access_mode="WRITE" if write else "READ"
     ) as session:
         yield session
+
+
+async def get_write_session() -> AsyncGenerator[AsyncSession, None]:
+    async for session in get_session(write=True):
+        yield session

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -2,14 +2,17 @@ from fastapi import APIRouter, Depends, HTTPException
 from neo4j import AsyncSession, exceptions
 
 from .websocket import broadcast
-from ..database import get_session
+from ..database import get_session, get_write_session
 from ..models.schemas import Project, ProjectCreate
 
 router = APIRouter(prefix="/projects", tags=["projects"])
 
 
 @router.post("/", response_model=Project)
-async def create_project(project: ProjectCreate, session: AsyncSession = Depends(get_session)):
+async def create_project(
+    project: ProjectCreate,
+    session: AsyncSession = Depends(get_write_session),
+):
     query = """CREATE (p:Project {name: $name}) RETURN id(p) AS id, p.name AS name"""
     try:
         result = await session.run(query, name=project.name)

--- a/backend/app/routers/relations.py
+++ b/backend/app/routers/relations.py
@@ -2,14 +2,17 @@ from fastapi import APIRouter, Depends, HTTPException
 from neo4j import AsyncSession, exceptions
 
 from .websocket import broadcast
-from ..database import get_session
+from ..database import get_session, get_write_session
 from ..models.schemas import Relation, RelationCreate
 
 router = APIRouter(prefix="/relations", tags=["relations"])
 
 
 @router.post("/", response_model=Relation)
-async def create_relation(rel: RelationCreate, session: AsyncSession = Depends(get_session)):
+async def create_relation(
+    rel: RelationCreate,
+    session: AsyncSession = Depends(get_write_session),
+):
     # verify source node exists
     try:
         res_src = await session.run(
@@ -53,7 +56,10 @@ async def create_relation(rel: RelationCreate, session: AsyncSession = Depends(g
 
 
 @router.delete("/{relation_id}")
-async def delete_relation(relation_id: int, session: AsyncSession = Depends(get_session)):
+async def delete_relation(
+    relation_id: int,
+    session: AsyncSession = Depends(get_write_session),
+):
     try:
         await session.run("MATCH ()-[r] WHERE id(r)=$id DELETE r", id=relation_id)
     except exceptions.ServiceUnavailable:

--- a/backend/tests/test_projects.py
+++ b/backend/tests/test_projects.py
@@ -1,7 +1,7 @@
 from fastapi.testclient import TestClient
 
 from app import app
-from app.database import get_session
+from app.database import get_session, get_write_session
 
 
 class FakeResult:
@@ -54,7 +54,7 @@ async def override_get_session_graph():
 
 
 def test_create_project():
-    app.dependency_overrides[get_session] = override_get_session
+    app.dependency_overrides[get_write_session] = override_get_session
     client = TestClient(app)
     response = client.post("/projects/", json={"name": "Demo"})
     assert response.status_code == 200


### PR DESCRIPTION
## Summary
- ensure write operations use a write session
- expose `get_write_session` helper
- adjust routers to depend on the write session
- update tests for new dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68493734fb8483289a455af358068986