### PR TITLE
Fix ReactFlow canvas sizing

### DIFF
--- a/frontend/src/components/GraphCanvas.tsx
+++ b/frontend/src/components/GraphCanvas.tsx
@@ -12,7 +12,13 @@ interface Props {
 export default function GraphCanvas({ nodes, edges, onChange }: Props) {
   const onConnect = (params: any) => onChange({ nodes, edges: addEdge(params, edges) })
   return (
-    <ReactFlow nodes={nodes} edges={edges} onConnect={onConnect} fitView className="h-full">
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      onConnect={onConnect}
+      fitView
+      className="w-full h-full"
+    >
       <MiniMap />
       <Controls />
       <Background />


### PR DESCRIPTION
## Summary
- ensure `GraphCanvas` passes width and height to ReactFlow

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68493cbe56ec83289fa5bf59ee07586b