### PR TITLE
Make project selection configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,9 @@ With both processes running the application is reachable at [http://localhost:51
 If the initial API request fails (for example due to a 404 or connection issue),
 the frontend shows an error message instead of the editor.
 
-### Create your first project
+### Create a project
 
-The frontend currently expects that a project with ID `1` exists. You can create
-it via the API using `curl`:
+The frontend can load any project ID. Create a project via the API:
 
 ```bash
 curl -X POST http://localhost:8000/projects/ \
@@ -51,6 +50,12 @@ curl -X POST http://localhost:8000/projects/ \
 
 Note the trailing slash in `/projects/`. Omitting it triggers a redirect that
 causes a `405 Method Not Allowed` error.
+
+Once created, note the numeric ID from the response. Specify this ID in the
+frontend by appending `?project=<id>` to the URL or by storing it in the
+browser's local storage under the key `projectId`. Visiting for example
+`http://localhost:5173/?project=2` will persist the ID `2` and load that
+project on subsequent visits.
 
 ### Configuration
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -12,6 +12,8 @@ npm run dev
 
 The development server proxies API requests starting with `/projects`, `/materials`,
 `/nodes`, `/relations`, `/score` and `/ws` to `http://localhost:8000`. Make sure
-the backend is running on that port before starting the frontend. On start it
-connects to the backend at the same host and loads project 1. When this request
-fails, the app displays an error message to help with troubleshooting.
+the backend is running on that port before starting the frontend. By default the
+client loads project `1`. You can open a different project by adding
+`?project=<id>` to the URL or by setting the `projectId` value in your browser's
+local storage. If the initial request fails, the app displays an error message to
+help with troubleshooting.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,8 +9,18 @@ export default function App() {
   const { state, setState, undo, redo } = useUndoRedo<GraphState>(data, 50)
   const [error, setError] = useState<string | null>(null)
 
+  const [projectId] = useState(() => {
+    const params = new URLSearchParams(window.location.search)
+    const query = params.get('project')
+    if (query) {
+      localStorage.setItem('projectId', query)
+      return query
+    }
+    return localStorage.getItem('projectId') ?? '1'
+  })
+
   useEffect(() => {
-    fetch('/projects/1/graph')
+    fetch(`/projects/${projectId}/graph`)
       .then(r => {
         if (!r.ok) {
           throw new Error(`HTTP ${r.status}`)
@@ -19,10 +29,10 @@ export default function App() {
       })
       .then(setState)
       .catch(() => setError('Failed to load project data'))
-  }, [])
+  }, [projectId])
 
   useEffect(() => {
-    const ws = new WebSocket(`ws://${window.location.host}/ws/projects/1`)
+    const ws = new WebSocket(`ws://${window.location.host}/ws/projects/${projectId}`)
     ws.onmessage = ev => {
       try {
         const msg: WsMessage = JSON.parse(ev.data)
@@ -32,7 +42,7 @@ export default function App() {
       }
     }
     return () => ws.close()
-  }, [setState])
+  }, [setState, projectId])
 
   if (error) {
     return <div className="p-4 text-red-600">{error}</div>


### PR DESCRIPTION
## Summary
- allow project selection via URL query parameter or `localStorage`
- document how to create and select a project

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_b_68493cc767c48328ad38861956790d9f