### PR TITLE
Fix WebSocket protocol selection

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -32,7 +32,8 @@ export default function App() {
   }, [projectId])
 
   useEffect(() => {
-    const ws = new WebSocket(`ws://${window.location.host}/ws/projects/${projectId}`)
+    const scheme = window.location.protocol === 'https:' ? 'wss' : 'ws'
+    const ws = new WebSocket(`${scheme}://${window.location.host}/ws/projects/${projectId}`)
     ws.onmessage = ev => {
       try {
         const msg: WsMessage = JSON.parse(ev.data)


### PR DESCRIPTION
## Summary
- ensure the client uses `wss://` when the site runs over HTTPS

## Testing
- `npm test --silent` *(fails: vitest not found)*
- `pytest` *(fails: ModuleNotFoundError: httpx)*

------
https://chatgpt.com/codex/tasks/task_b_6849433cc3688328a2f34e5f039dea6a