### PR TITLE
Add TESTING env to skip DB check

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -10,6 +10,8 @@ NEO4J_PASSWORD=your_password uvicorn app.main:app --reload
 
 By default the app expects a local Neo4j instance reachable at `bolt://localhost:7687` with user/password `neo4j/your_password`. Set `NEO4J_URI`, `NEO4J_USER`, and `NEO4J_PASSWORD` to override.
 
+During startup the app verifies the database connection. Set the environment variable `TESTING=1` to skip this check (used by the test suite).
+
 The `pyproject.toml` file is kept only for reference and is not used by these instructions.
 
 

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,3 +1,5 @@
+import os
+
 from fastapi import FastAPI
 
 from .database import verify_connectivity
@@ -9,7 +11,8 @@ app = FastAPI(title="Circular Design Toolkit")
 
 @app.on_event("startup")
 async def startup() -> None:
-    await verify_connectivity()
+    if not os.getenv("TESTING"):
+        await verify_connectivity()
 
 app.include_router(projects.router)
 app.include_router(materials.router)

--- a/backend/tests/test_projects.py
+++ b/backend/tests/test_projects.py
@@ -1,3 +1,7 @@
+import os
+
+os.environ["TESTING"] = "1"
+
 from fastapi.testclient import TestClient
 
 from app import app


### PR DESCRIPTION
## Summary
- skip Neo4j connectivity check when `TESTING` env var is set
- set `TESTING=1` in the backend tests
- document the new variable in the backend README

## Testing
- `pytest -q`
- `ruff check .` *(fails: `app/routers/relations.py:5:24 F401 imported but unused`)*

------
https://chatgpt.com/codex/tasks/task_e_68494cb226388332998a2a50e477679c