### PR TITLE
Implement FastAPI lifespan

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,4 +1,5 @@
 import os
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
@@ -6,13 +7,15 @@ from .database import verify_connectivity
 
 from .routers import projects, materials, nodes, relations, score, websocket
 
-app = FastAPI(title="Circular Design Toolkit")
 
-
-@app.on_event("startup")
-async def startup() -> None:
+@asynccontextmanager
+async def lifespan(app: FastAPI):
     if not os.getenv("TESTING"):
         await verify_connectivity()
+    yield
+
+
+app = FastAPI(title="Circular Design Toolkit", lifespan=lifespan)
 
 app.include_router(projects.router)
 app.include_router(materials.router)


### PR DESCRIPTION
## Summary
- refactor `backend/app/__init__.py` to use FastAPI lifespan events
- move database connectivity check into the lifespan startup
- drop the deprecated `@app.on_event` handler

## Testing
- `ruff check backend/app/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684984d903d0833295058d4dd032e340