### PR TITLE
Make WebSocket host configurable

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -10,6 +10,17 @@ npm install
 npm run dev
 ```
 
+### WebSocket host
+
+The app connects to `localhost:8000` for WebSocket updates by default. Set the
+`VITE_WS_HOST` environment variable to change this when running the dev server or
+building for production.
+
+```bash
+# Example for a remote backend
+VITE_WS_HOST=api.example.com:8000 npm run dev
+```
+
 The development server proxies API requests starting with `/projects`, `/materials`,
 `/nodes`, `/relations`, `/score` and `/socket` to `http://localhost:8000`. Make sure
 the backend is running on that port before starting the frontend. By default the

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -48,7 +48,8 @@ export default function App() {
     if (wsRef.current) return // already connected
 
     const scheme = window.location.protocol === 'https:' ? 'wss' : 'ws'
-    const wsUrl = `${scheme}://localhost:8000/ws/projects/${projectId}`
+    const host = import.meta.env.VITE_WS_HOST ?? 'localhost:8000'
+    const wsUrl = `${scheme}://${host}/ws/projects/${projectId}`
     console.log(`Attempting to connect WebSocket to: ${wsUrl}`)
 
     const ws = new WebSocket(wsUrl)


### PR DESCRIPTION
## Summary
- configure WebSocket host via `VITE_WS_HOST` in `App.tsx`
- document how to set `VITE_WS_HOST` in the frontend README

## Testing
- `npm run test` in `frontend`
- `npx eslint .` *(fails: ESLint couldn't find a configuration file)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684984f0e2508332b972a3458b8d199b