### PR TITLE
Fix flake8 warnings in routers

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -4,8 +4,15 @@ import os
 from neo4j import AsyncGraphDatabase, AsyncSession, exceptions
 
 
-def get_driver(uri: str, user: str | None = None, password: str | None = None):
-    return AsyncGraphDatabase.driver(uri, auth=(user or None, password or None))
+def get_driver(
+    uri: str,
+    user: str | None = None,
+    password: str | None = None,
+):
+    return AsyncGraphDatabase.driver(
+        uri,
+        auth=(user or None, password or None),
+    )
 
 
 driver = get_driver(
@@ -13,6 +20,7 @@ driver = get_driver(
     user=os.getenv("NEO4J_USER", "neo4j"),
     password=os.getenv("NEO4J_PASSWORD", "your_password"),
 )
+
 
 async def verify_connectivity() -> None:
     """Ensure the Neo4j database is reachable."""
@@ -22,9 +30,11 @@ async def verify_connectivity() -> None:
         raise RuntimeError("Unable to connect to Neo4j") from exc
 
 
-async def get_session(*, write: bool = False) -> AsyncGenerator[AsyncSession, None]:
+async def get_session(
+    *, write: bool = False,
+) -> AsyncGenerator[AsyncSession, None]:
     async with driver.session(
-        default_access_mode="WRITE" if write else "READ"
+        default_access_mode="WRITE" if write else "READ",
     ) as session:
         yield session
 

--- a/backend/app/routers/materials.py
+++ b/backend/app/routers/materials.py
@@ -13,21 +13,38 @@ async def create_material(
     material: MaterialCreate,
     session: AsyncSession = Depends(get_write_session),
 ):
-    query = """CREATE (m:Material {name: $name, weight: $weight}) RETURN id(m) AS id, m.name AS name, m.weight AS weight"""
+    query = (
+        "CREATE (m:Material {name: $name, weight: $weight}) "
+        "RETURN id(m) AS id, m.name AS name, m.weight AS weight"
+    )
     try:
-        result = await session.run(query, name=material.name, weight=material.weight)
+        result = await session.run(
+            query,
+            name=material.name,
+            weight=material.weight,
+        )
     except exceptions.ServiceUnavailable:
         raise HTTPException(status_code=503, detail="Neo4j unavailable")
     record = await result.single()
     if not record:
         raise HTTPException(status_code=404, detail="Resource not found")
     await broadcast(0, {"op": "create_material", "id": record["id"]})
-    return Material(id=record["id"], name=record["name"], weight=record["weight"])
+    return Material(
+        id=record["id"],
+        name=record["name"],
+        weight=record["weight"],
+    )
 
 
 @router.get("/{material_id}", response_model=Material)
-async def get_material(material_id: int, session: AsyncSession = Depends(get_session)):
-    query = "MATCH (m:Material) WHERE id(m)=$id RETURN id(m) AS id, m.name AS name, m.weight AS weight"
+async def get_material(
+    material_id: int,
+    session: AsyncSession = Depends(get_session),
+):
+    query = (
+        "MATCH (m:Material) WHERE id(m)=$id "
+        "RETURN id(m) AS id, m.name AS name, m.weight AS weight"
+    )
     try:
         result = await session.run(query, id=material_id)
     except exceptions.ServiceUnavailable:
@@ -35,7 +52,11 @@ async def get_material(material_id: int, session: AsyncSession = Depends(get_ses
     record = await result.single()
     if not record:
         raise HTTPException(status_code=404, detail="Material not found")
-    return Material(id=record["id"], name=record["name"], weight=record["weight"])
+    return Material(
+        id=record["id"],
+        name=record["name"],
+        weight=record["weight"],
+    )
 
 
 @router.delete("/{material_id}")
@@ -44,7 +65,10 @@ async def delete_material(
     session: AsyncSession = Depends(get_write_session),
 ):
     try:
-        await session.run("MATCH (m:Material) WHERE id(m)=$id DETACH DELETE m", id=material_id)
+        await session.run(
+            "MATCH (m:Material) WHERE id(m)=$id DETACH DELETE m",
+            id=material_id,
+        )
     except exceptions.ServiceUnavailable:
         raise HTTPException(status_code=503, detail="Neo4j unavailable")
     await broadcast(0, {"op": "delete_material", "id": material_id})

--- a/backend/app/routers/nodes.py
+++ b/backend/app/routers/nodes.py
@@ -14,26 +14,42 @@ async def create_node(
     session: AsyncSession = Depends(get_write_session),
 ):
     query = (
-        """MATCH (p:Project) WHERE id(p)=$pid MATCH (m:Material) WHERE id(m)=$mid """
-        "CREATE (n:Node {level: $level})-[:USES]->(m), (n)-[:PART_OF]->(p) RETURN id(n) AS id"
+        "MATCH (p:Project) WHERE id(p)=$pid "
+        "MATCH (m:Material) WHERE id(m)=$mid "
+        "CREATE (n:Node {level: $level})-[:USES]->(m), "
+        "(n)-[:PART_OF]->(p) RETURN id(n) AS id"
     )
     try:
-        result = await session.run(query, pid=node.project_id, mid=node.material_id, level=node.level)
+        result = await session.run(
+            query,
+            pid=node.project_id,
+            mid=node.material_id,
+            level=node.level,
+        )
     except exceptions.ServiceUnavailable:
         raise HTTPException(status_code=503, detail="Neo4j unavailable")
     record = await result.single()
     if not record:
         raise HTTPException(status_code=404, detail="Resource not found")
     await broadcast(node.project_id, {"op": "create_node", "id": record["id"]})
-    return Node(id=record["id"], project_id=node.project_id, material_id=node.material_id, level=node.level)
+    return Node(
+        id=record["id"],
+        project_id=node.project_id,
+        material_id=node.material_id,
+        level=node.level,
+    )
 
 
 @router.get("/{node_id}", response_model=Node)
-async def get_node(node_id: int, session: AsyncSession = Depends(get_session)):
+async def get_node(
+    node_id: int,
+    session: AsyncSession = Depends(get_session),
+):
     query = (
         "MATCH (n:Node)-[:USES]->(m:Material) WHERE id(n)=$id "
         "MATCH (n)-[:PART_OF]->(p:Project) "
-        "RETURN id(n) AS id, id(p) AS project_id, id(m) AS material_id, n.level AS level"
+        "RETURN id(n) AS id, id(p) AS project_id, id(m) AS material_id, "
+        "n.level AS level"
     )
     try:
         result = await session.run(query, id=node_id)
@@ -51,13 +67,20 @@ async def delete_node(
     session: AsyncSession = Depends(get_write_session),
 ):
     try:
-        result = await session.run("MATCH (n:Node)-[:PART_OF]->(p) WHERE id(n)=$id RETURN id(p) AS pid", id=node_id)
+        result = await session.run(
+            "MATCH (n:Node)-[:PART_OF]->(p) WHERE id(n)=$id "
+            "RETURN id(p) AS pid",
+            id=node_id,
+        )
     except exceptions.ServiceUnavailable:
         raise HTTPException(status_code=503, detail="Neo4j unavailable")
     rec = await result.single()
     pid = rec["pid"] if rec else 0
     try:
-        await session.run("MATCH (n:Node) WHERE id(n)=$id DETACH DELETE n", id=node_id)
+        await session.run(
+            "MATCH (n:Node) WHERE id(n)=$id DETACH DELETE n",
+            id=node_id,
+        )
     except exceptions.ServiceUnavailable:
         raise HTTPException(status_code=503, detail="Neo4j unavailable")
     await broadcast(pid, {"op": "delete_node", "id": node_id})

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -13,7 +13,10 @@ async def create_project(
     project: ProjectCreate,
     session: AsyncSession = Depends(get_write_session),
 ):
-    query = """CREATE (p:Project {name: $name}) RETURN id(p) AS id, p.name AS name"""
+    query = (
+        "CREATE (p:Project {name: $name}) "
+        "RETURN id(p) AS id, p.name AS name"
+    )
     try:
         result = await session.run(query, name=project.name)
     except exceptions.ServiceUnavailable:
@@ -26,8 +29,14 @@ async def create_project(
 
 
 @router.get("/{project_id}", response_model=Project)
-async def get_project(project_id: int, session: AsyncSession = Depends(get_session)):
-    query = "MATCH (p:Project) WHERE id(p)=$id RETURN id(p) AS id, p.name AS name"
+async def get_project(
+    project_id: int,
+    session: AsyncSession = Depends(get_session),
+):
+    query = (
+        "MATCH (p:Project) WHERE id(p)=$id "
+        "RETURN id(p) AS id, p.name AS name"
+    )
     try:
         result = await session.run(query, id=project_id)
     except exceptions.ServiceUnavailable:
@@ -39,20 +48,33 @@ async def get_project(project_id: int, session: AsyncSession = Depends(get_sessi
 
 
 @router.get("/{project_id}/graph")
-async def get_graph(project_id: int, session: AsyncSession = Depends(get_session)):
-    q_nodes = "MATCH (p:Project)<-[:PART_OF]-(n:Node)-[:USES]->(m:Material) WHERE id(p)=$pid RETURN id(n) AS id, id(m) AS material_id, n.level AS level"
+async def get_graph(
+    project_id: int,
+    session: AsyncSession = Depends(get_session),
+):
+    q_nodes = (
+        "MATCH (p:Project)<-[:PART_OF]-(n:Node)-[:USES]->(m:Material) "
+        "WHERE id(p)=$pid RETURN id(n) AS id, id(m) AS material_id, "
+        "n.level AS level"
+    )
     try:
         result = await session.run(q_nodes, pid=project_id)
     except exceptions.ServiceUnavailable:
         raise HTTPException(status_code=503, detail="Neo4j unavailable")
     nodes = await result.data()
-    q_edges = "MATCH (p:Project)<-[:PART_OF]-(s:Node)-[r:LINK]->(t:Node) WHERE id(p)=$pid RETURN id(r) AS id, id(s) AS source, id(t) AS target"
+    q_edges = (
+        "MATCH (p:Project)<-[:PART_OF]-(s:Node)-[r:LINK]->(t:Node) "
+        "WHERE id(p)=$pid RETURN id(r) AS id, id(s) AS source, id(t) AS target"
+    )
     try:
         res_e = await session.run(q_edges, pid=project_id)
     except exceptions.ServiceUnavailable:
         raise HTTPException(status_code=503, detail="Neo4j unavailable")
     edges = await res_e.data()
-    q_mats = "MATCH (m:Material) RETURN id(m) AS id, m.name AS name, m.weight AS weight"
+    q_mats = (
+        "MATCH (m:Material) RETURN id(m) AS id, m.name AS name, "
+        "m.weight AS weight"
+    )
     try:
         res_m = await session.run(q_mats)
     except exceptions.ServiceUnavailable:

--- a/backend/app/routers/score.py
+++ b/backend/app/routers/score.py
@@ -7,7 +7,10 @@ router = APIRouter(tags=["score"])
 
 
 @router.post("/score/{project_id}")
-async def score_project(project_id: int, session: AsyncSession = Depends(get_session)):
+async def score_project(
+    project_id: int,
+    session: AsyncSession = Depends(get_session),
+):
     query = (
         "MATCH (p:Project)<-[:PART_OF]-(n:Node)-[:USES]->(m:Material) "
         "WHERE id(p)=$pid RETURN sum(m.weight) AS total"


### PR DESCRIPTION
## Summary
- format database helpers
- wrap long lines in materials, nodes and projects routers
- adjust relations router imports and formatting
- tidy score router endpoint definition

## Testing
- `pytest -q`
- `flake8 app`

------
https://chatgpt.com/codex/tasks/task_e_684984f662ac8332aa07504607dd9fbc