### PR TITLE
Fix WebSocket path

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -49,7 +49,7 @@ export default function App() {
 
     const scheme = window.location.protocol === 'https:' ? 'wss' : 'ws'
     const host = import.meta.env.VITE_WS_HOST ?? 'localhost:8000'
-    const wsUrl = `${scheme}://${host}/ws/projects/${projectId}`
+    const wsUrl = `${scheme}://${host}/socket/projects/${projectId}`
     console.log(`Attempting to connect WebSocket to: ${wsUrl}`)
 
     const ws = new WebSocket(wsUrl)


### PR DESCRIPTION
## Summary
- update websocket URL in the frontend to use `/socket/projects`

## Testing
- `pytest -q`
- `npm test --silent`
- `npx wscat -c ws://localhost:8000/socket/projects/1`

------
https://chatgpt.com/codex/tasks/task_b_68498812f400832897bcb6baf8dff80b