### PR TITLE
Update frontend docs about Tailwind build

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -10,6 +10,16 @@ npm install
 npm run dev
 ```
 
+### Tailwind CSS
+
+The `postcss.config.cjs` file configures PostCSS with the
+`tailwindcss` and `autoprefixer` plugins. After running `npm install`
+you can start the development server with `npm run dev`; Vite will
+compile the Tailwind styles automatically using this configuration.
+Production builds created via `npm run build` also compile the CSS so
+no additional steps are required. Ensure you have Node.js 18 or newer
+installed.
+
 ### WebSocket host
 
 The app connects to `localhost:8000` for WebSocket updates by default. Set the


### PR DESCRIPTION
## Summary
- document PostCSS config and automatic Tailwind builds in `frontend/README.md`

## Testing
- `npm test --silent` in `frontend`
- `pytest -q` in `backend`

------
https://chatgpt.com/codex/tasks/task_b_68498afc6e308328be0dfd5aafad0110