### PR TITLE
Implement node/edge creation features

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,7 +34,15 @@ export default function App() {
         }
         return r.json()
       })
-      .then(setState)
+      .then((data) =>
+        setState({
+          ...data,
+          nodes: data.nodes.map((n: any) => ({
+            ...n,
+            position: { x: Math.random() * 250, y: Math.random() * 250 },
+          })),
+        })
+      )
       .catch(() => setError('Failed to load project data'))
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [projectId])
@@ -85,11 +93,38 @@ export default function App() {
     return <div className="p-4 text-red-600">{error}</div>
   }
 
+  const addNode = () => {
+    if (!state.materials.length) return
+    fetch('/nodes/', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        project_id: Number(projectId),
+        material_id: state.materials[0].id,
+        level: 0,
+      }),
+    }).catch((err) => console.error(err))
+  }
+
+  const handleConnect = (connection: any) => {
+    if (!connection.source || !connection.target) return
+    fetch('/relations/', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        project_id: Number(projectId),
+        source_id: Number(connection.source),
+        target_id: Number(connection.target),
+      }),
+    }).catch((err) => console.error(err))
+  }
+
   return (
     <div className="flex h-full w-full">
       <div className="w-2/3 h-full">
-        <GraphCanvas nodes={state.nodes} edges={state.edges} onChange={setState} />
+        <GraphCanvas nodes={state.nodes} edges={state.edges} onConnectEdge={handleConnect} />
         <div className="p-2 space-x-2">
+          <button onClick={addNode}>Add Node</button>
           <button onClick={undo}>Undo</button>
           <button onClick={redo}>Redo</button>
         </div>

--- a/frontend/src/components/GraphCanvas.tsx
+++ b/frontend/src/components/GraphCanvas.tsx
@@ -1,21 +1,20 @@
 import React from 'react'
-import ReactFlow, { MiniMap, Controls, Background, addEdge } from 'reactflow'
+import ReactFlow, { MiniMap, Controls, Background, Connection } from 'reactflow'
 import 'reactflow/dist/style.css'
 
 
 interface Props {
   nodes: any[]
   edges: any[]
-  onChange: (state: { nodes: any[]; edges: any[] }) => void
+  onConnectEdge: (connection: Connection) => void
 }
 
-export default function GraphCanvas({ nodes, edges, onChange }: Props) {
-  const onConnect = (params: any) => onChange({ nodes, edges: addEdge(params, edges) })
+export default function GraphCanvas({ nodes, edges, onConnectEdge }: Props) {
   return (
     <ReactFlow
       nodes={nodes}
       edges={edges}
-      onConnect={onConnect}
+      onConnect={onConnectEdge}
       fitView
       style={{ width: '100%', height: '100%' }}
     >

--- a/frontend/src/wsMessage.ts
+++ b/frontend/src/wsMessage.ts
@@ -13,10 +13,20 @@ export function applyWsMessage(state: GraphState, msg: WsMessage): GraphState {
   switch (msg.op) {
     case 'create_node':
       if ('node' in msg) {
-        return { ...state, nodes: [...state.nodes, msg.node] }
+        const n = msg.node
+        if (!('position' in n)) {
+          n.position = { x: Math.random() * 250, y: Math.random() * 250 }
+        }
+        return { ...state, nodes: [...state.nodes, n] }
       }
       if ('id' in msg) {
-        return { ...state, nodes: [...state.nodes, { id: msg.id }] }
+        return {
+          ...state,
+          nodes: [
+            ...state.nodes,
+            { id: msg.id, position: { x: Math.random() * 250, y: Math.random() * 250 } },
+          ],
+        }
       }
       return state
     case 'delete_node':


### PR DESCRIPTION
## Summary
- allow new edges to be sent to the backend from the canvas
- hook in a simple `Add Node` button
- randomize node positions when created via websocket

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68498e3fcac083289e43c57e653dabad