### PR TITLE
Improve node creation

### DIFF
--- a/backend/app/routers/nodes.py
+++ b/backend/app/routers/nodes.py
@@ -31,13 +31,14 @@ async def create_node(
     record = await result.single()
     if not record:
         raise HTTPException(status_code=404, detail="Resource not found")
-    await broadcast(node.project_id, {"op": "create_node", "id": record["id"]})
-    return Node(
-        id=record["id"],
-        project_id=node.project_id,
-        material_id=node.material_id,
-        level=node.level,
-    )
+    node_data = {
+        "id": record["id"],
+        "project_id": node.project_id,
+        "material_id": node.material_id,
+        "level": node.level,
+    }
+    await broadcast(node.project_id, {"op": "create_node", "node": node_data})
+    return Node(**node_data)
 
 
 @router.get("/{node_id}", response_model=Node)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -103,7 +103,17 @@ export default function App() {
         material_id: state.materials[0].id,
         level: 0,
       }),
-    }).catch((err) => console.error(err))
+    })
+      .then(r => (r.ok ? r.json() : Promise.reject(r.status)))
+      .then(node =>
+        setState(prev =>
+          applyWsMessage(prev, {
+            op: 'create_node',
+            node,
+          })
+        )
+      )
+      .catch(err => console.error(err))
   }
 
   const handleConnect = (connection: any) => {

--- a/frontend/src/__tests__/wsMessage.test.ts
+++ b/frontend/src/__tests__/wsMessage.test.ts
@@ -6,7 +6,8 @@ describe('applyWsMessage', () => {
     const state: GraphState = { nodes: [], edges: [], materials: [] }
     const result = applyWsMessage(state, { op: 'create_node', node: { id: 1 } })
     expect(result.nodes).toHaveLength(1)
-    expect(result.nodes[0]).toEqual({ id: 1 })
+    expect(result.nodes[0]).toHaveProperty('id', 1)
+    expect(result.nodes[0]).toHaveProperty('position')
   })
 
   it('ignores unknown op', () => {

--- a/frontend/src/wsMessage.ts
+++ b/frontend/src/wsMessage.ts
@@ -13,9 +13,12 @@ export function applyWsMessage(state: GraphState, msg: WsMessage): GraphState {
   switch (msg.op) {
     case 'create_node':
       if ('node' in msg) {
-        const n = msg.node
-        if (!('position' in n)) {
-          n.position = { x: Math.random() * 250, y: Math.random() * 250 }
+        const n = {
+          ...msg.node,
+          position: msg.node.position ?? {
+            x: Math.random() * 250,
+            y: Math.random() * 250,
+          },
         }
         return { ...state, nodes: [...state.nodes, n] }
       }


### PR DESCRIPTION
## Summary
- broadcast node details when creating nodes
- update node creation button to persist nodes immediately
- don't mutate incoming nodes in ws message reducer
- adjust tests for new node behaviour

## Testing
- `pytest -q`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_b_684990ef1f7c832884bac1dd75bb5d7c