### PR TITLE
Add component state and dialog

### DIFF
--- a/frontend/src/__tests__/wsMessage.test.ts
+++ b/frontend/src/__tests__/wsMessage.test.ts
@@ -10,6 +10,30 @@ describe('applyWsMessage', () => {
     expect(result.nodes[0]).toHaveProperty('position')
   })
 
+  it('preserves component fields on create_node', () => {
+    const state: GraphState = { nodes: [], edges: [], materials: [] }
+    const result = applyWsMessage(state, {
+      op: 'create_node',
+      node: {
+        id: 2,
+        name: 'Comp',
+        level: 1,
+        parent_id: null,
+        atomic: true,
+        weight: 3,
+        reusable: false,
+        connection_type: 'bolted',
+        material_id: 5,
+      },
+    })
+    const n = result.nodes[0]
+    expect(n.name).toBe('Comp')
+    expect(n.level).toBe(1)
+    expect(n.atomic).toBe(true)
+    expect(n.weight).toBe(3)
+    expect(n.connection_type).toBe('bolted')
+  })
+
   it('ignores unknown op', () => {
     const state: GraphState = { nodes: [], edges: [], materials: [] }
     const result = applyWsMessage(state, { op: 'unknown', foo: 'bar' })

--- a/frontend/src/components/ComponentTable.tsx
+++ b/frontend/src/components/ComponentTable.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import {
+  useReactTable,
+  createColumnHelper,
+  flexRender,
+  getCoreRowModel,
+} from '@tanstack/react-table'
+import { Component } from '../wsMessage'
+
+interface Props {
+  components: Component[]
+}
+
+const columnHelper = createColumnHelper<Component>()
+
+export default function ComponentTable({ components }: Props) {
+  const columns = [
+    columnHelper.accessor('name', { header: 'Name' }),
+    columnHelper.accessor('level', { header: 'Level' }),
+    columnHelper.accessor('weight', { header: 'Weight' }),
+    columnHelper.accessor('material_id', { header: 'Material' }),
+  ]
+
+  const table = useReactTable({
+    data: components,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  })
+
+  return (
+    <table className="min-w-full text-sm">
+      <thead>
+        {table.getHeaderGroups().map(hg => (
+          <tr key={hg.id}>
+            {hg.headers.map(header => (
+              <th key={header.id}>{flexRender(header.column.columnDef.header, header.getContext())}</th>
+            ))}
+          </tr>
+        ))}
+      </thead>
+      <tbody>
+        {table.getRowModel().rows.map(row => (
+          <tr key={row.id}>
+            {row.getVisibleCells().map(cell => (
+              <td key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}

--- a/frontend/src/wsMessage.ts
+++ b/frontend/src/wsMessage.ts
@@ -1,7 +1,32 @@
+export interface Component {
+  id: number
+  name?: string
+  level?: number
+  parent_id?: number | null
+  atomic?: boolean
+  weight?: number
+  reusable?: boolean
+  connection_type?: string
+  material_id?: number
+  position?: { x: number; y: number }
+}
+
+export interface Material {
+  id: number
+  name?: string
+  weight?: number
+}
+
+export interface Edge {
+  id: number
+  source: number
+  target: number
+}
+
 export interface GraphState {
-  nodes: any[]
-  edges: any[]
-  materials: any[]
+  nodes: Component[]
+  edges: Edge[]
+  materials: Material[]
 }
 
 export interface WsMessage {


### PR DESCRIPTION
## Summary
- support additional component fields in GraphState
- add dialog form for creating nodes
- show a ComponentTable instead of MaterialTable
- test state updates for the extra fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68515c3d0cec832892661ba92c886e86