### PR TITLE
Disable weight input when atomic nodes selected

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -224,6 +224,7 @@ export default function App() {
               step="any"
               placeholder="Weight"
               value={newNode.weight}
+              disabled={newNode.atomic}
               onChange={e => setNewNode({ ...newNode, weight: Number(e.target.value) })}
             />
             <label className="block">


### PR DESCRIPTION
## Summary
- disable the Weight input in the new node form when the Atomic option is checked

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_b_68516073a51c832894d8ce0c10910e90