### PR TITLE
Add CO2 value and hardness to materials

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -6,6 +6,8 @@ from pydantic import BaseModel, Field
 class MaterialBase(BaseModel):
     name: str = Field(..., example="Aluminum")
     weight: float = Field(..., gt=0)
+    co2_value: float = Field(..., gt=0)
+    hardness: float = Field(..., gt=0)
 
 
 class MaterialCreate(MaterialBase):

--- a/backend/app/routers/materials.py
+++ b/backend/app/routers/materials.py
@@ -14,14 +14,16 @@ async def create_material(
     session: AsyncSession = Depends(get_write_session),
 ):
     query = (
-        "CREATE (m:Material {name: $name, weight: $weight}) "
-        "RETURN id(m) AS id, m.name AS name, m.weight AS weight"
+        "CREATE (m:Material {name: $name, weight: $weight, co2_value: $co2_value, hardness: $hardness}) "
+        "RETURN id(m) AS id, m.name AS name, m.weight AS weight, m.co2_value AS co2_value, m.hardness AS hardness"
     )
     try:
         result = await session.run(
             query,
             name=material.name,
             weight=material.weight,
+            co2_value=material.co2_value,
+            hardness=material.hardness,
         )
     except exceptions.ServiceUnavailable:
         raise HTTPException(status_code=503, detail="Neo4j unavailable")
@@ -33,6 +35,8 @@ async def create_material(
         id=record["id"],
         name=record["name"],
         weight=record["weight"],
+        co2_value=record["co2_value"],
+        hardness=record["hardness"],
     )
 
 
@@ -43,7 +47,7 @@ async def get_material(
 ):
     query = (
         "MATCH (m:Material) WHERE id(m)=$id "
-        "RETURN id(m) AS id, m.name AS name, m.weight AS weight"
+        "RETURN id(m) AS id, m.name AS name, m.weight AS weight, m.co2_value AS co2_value, m.hardness AS hardness"
     )
     try:
         result = await session.run(query, id=material_id)
@@ -56,6 +60,8 @@ async def get_material(
         id=record["id"],
         name=record["name"],
         weight=record["weight"],
+        co2_value=record["co2_value"],
+        hardness=record["hardness"],
     )
 
 

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -75,7 +75,7 @@ async def get_graph(
     edges = await res_e.data()
     q_mats = (
         "MATCH (m:Material) RETURN id(m) AS id, m.name AS name, "
-        "m.weight AS weight"
+        "m.weight AS weight, m.co2_value AS co2_value, m.hardness AS hardness"
     )
     try:
         res_m = await session.run(q_mats)

--- a/backend/tests/test_projects.py
+++ b/backend/tests/test_projects.py
@@ -73,7 +73,13 @@ class FakeSessionGraph:
             ])
         else:
             return FakeResultList([
-                {"id": 2, "name": "Steel", "weight": 7.8}
+                {
+                    "id": 2,
+                    "name": "Steel",
+                    "weight": 7.8,
+                    "co2_value": 1.0,
+                    "hardness": 10.0,
+                }
             ])
 
 
@@ -131,7 +137,13 @@ def test_get_graph():
             },
         ],
         "edges": [{"id": 10, "source": 1, "target": 2}],
-        "materials": [{"id": 2, "name": "Steel", "weight": 7.8}],
+        "materials": [{
+            "id": 2,
+            "name": "Steel",
+            "weight": 7.8,
+            "co2_value": 1.0,
+            "hardness": 10.0,
+        }],
     }
     app.dependency_overrides.clear()
 


### PR DESCRIPTION
## Summary
- extend Material models with `co2_value` and `hardness`
- store and fetch these fields via Neo4j in materials router
- include new material properties when fetching project graphs
- adjust tests for the added attributes

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685163bb206883329a0d95fd076bf4ee