### PR TITLE
Add cycle detection to calc_weight

### DIFF
--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -84,18 +84,23 @@ async def get_graph(
     materials = await res_m.data()
     node_map = {n["id"]: n for n in nodes}
 
-    def calc_weight(nid: int) -> float:
+    def calc_weight(nid: int, visited: set[int]) -> float:
+        if nid in visited:
+            raise HTTPException(status_code=400, detail="Cycle detected")
+        visited.add(nid)
         node = node_map[nid]
         if node.get("atomic"):
+            visited.remove(nid)
             return node.get("weight", 0)
         total = 0.0
         for ch in nodes:
             if ch.get("parent_id") == nid:
-                total += calc_weight(ch["id"])
+                total += calc_weight(ch["id"], visited)
         node["weight"] = total
+        visited.remove(nid)
         return total
 
     for n in nodes:
         if not n.get("atomic"):
-            calc_weight(n["id"])
+            calc_weight(n["id"], set())
     return {"nodes": nodes, "edges": edges, "materials": materials}

--- a/backend/tests/test_projects.py
+++ b/backend/tests/test_projects.py
@@ -77,12 +77,60 @@ class FakeSessionGraph:
             ])
 
 
+class FakeSessionGraphCycle:
+    def __init__(self):
+        self._calls = 0
+
+    async def run(self, query, **params):
+        self._calls += 1
+        if self._calls == 1:
+            return FakeResultList([
+                {
+                    "id": 1,
+                    "material_id": 2,
+                    "name": "A",
+                    "parent_id": 2,
+                    "atomic": False,
+                    "reusable": False,
+                    "connection_type": "bolt",
+                    "level": 0,
+                    "weight": 0.0,
+                    "recyclable": True,
+                },
+                {
+                    "id": 2,
+                    "material_id": 2,
+                    "name": "B",
+                    "parent_id": 1,
+                    "atomic": False,
+                    "reusable": False,
+                    "connection_type": "bolt",
+                    "level": 1,
+                    "weight": 0.0,
+                    "recyclable": True,
+                },
+            ])
+        elif self._calls == 2:
+            return FakeResultList([
+                {"id": 10, "source": 1, "target": 2},
+                {"id": 11, "source": 2, "target": 1},
+            ])
+        else:
+            return FakeResultList([
+                {"id": 2, "name": "Steel", "weight": 7.8}
+            ])
+
+
 async def override_get_session():
     yield FakeSession()
 
 
 async def override_get_session_graph():
     yield FakeSessionGraph()
+
+
+async def override_get_session_graph_cycle():
+    yield FakeSessionGraphCycle()
 
 
 async def override_get_session_node():
@@ -133,6 +181,15 @@ def test_get_graph():
         "edges": [{"id": 10, "source": 1, "target": 2}],
         "materials": [{"id": 2, "name": "Steel", "weight": 7.8}],
     }
+    app.dependency_overrides.clear()
+
+
+def test_get_graph_cycle():
+    app.dependency_overrides[get_session] = override_get_session_graph_cycle
+    client = TestClient(app)
+    response = client.get("/projects/1/graph")
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Cycle detected"}
     app.dependency_overrides.clear()
 
 


### PR DESCRIPTION
## Summary
- prevent infinite recursion in `calc_weight` by tracking visited nodes
- handle cycles in the projects graph API
- add tests to verify cycle detection

## Testing
- `ruff check backend/app/routers/projects.py`
- `ruff check backend/tests/test_projects.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685163cb4254833289c241391b20a35e