### PR TITLE
Update connection_type field

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -26,7 +26,7 @@ class NodeBase(BaseModel):
     parent_id: int | None = None
     atomic: bool
     reusable: bool
-    connection_type: str | None = None
+    connection_type: int | None = Field(None, ge=0, le=5)
     level: int
     weight: float
     recyclable: bool

--- a/backend/tests/test_projects.py
+++ b/backend/tests/test_projects.py
@@ -41,40 +41,38 @@ class FakeSessionGraph:
     async def run(self, query, **params):
         self._calls += 1
         if self._calls == 1:
-            return FakeResultList([
-                {
-                    "id": 1,
-                    "material_id": 2,
-                    "name": "Parent",
-                    "parent_id": None,
-                    "atomic": False,
-                    "reusable": False,
-                    "connection_type": "bolt",
-                    "level": 0,
-                    "weight": 0.0,
-                    "recyclable": True,
-                },
-                {
-                    "id": 2,
-                    "material_id": 3,
-                    "name": "Child",
-                    "parent_id": 1,
-                    "atomic": True,
-                    "reusable": False,
-                    "connection_type": "bolt",
-                    "level": 1,
-                    "weight": 1.0,
-                    "recyclable": True,
-                },
-            ])
+            return FakeResultList(
+                [
+                    {
+                        "id": 1,
+                        "material_id": 2,
+                        "name": "Parent",
+                        "parent_id": None,
+                        "atomic": False,
+                        "reusable": False,
+                        "connection_type": 1,
+                        "level": 0,
+                        "weight": 0.0,
+                        "recyclable": True,
+                    },
+                    {
+                        "id": 2,
+                        "material_id": 3,
+                        "name": "Child",
+                        "parent_id": 1,
+                        "atomic": True,
+                        "reusable": False,
+                        "connection_type": 1,
+                        "level": 1,
+                        "weight": 1.0,
+                        "recyclable": True,
+                    },
+                ]
+            )
         elif self._calls == 2:
-            return FakeResultList([
-                {"id": 10, "source": 1, "target": 2}
-            ])
+            return FakeResultList([{"id": 10, "source": 1, "target": 2}])
         else:
-            return FakeResultList([
-                {"id": 2, "name": "Steel", "weight": 7.8}
-            ])
+            return FakeResultList([{"id": 2, "name": "Steel", "weight": 7.8}])
 
 
 async def override_get_session():
@@ -112,7 +110,7 @@ def test_get_graph():
                 "parent_id": None,
                 "atomic": False,
                 "reusable": False,
-                "connection_type": "bolt",
+                "connection_type": 1,
                 "level": 0,
                 "weight": 1.0,
                 "recyclable": True,
@@ -124,7 +122,7 @@ def test_get_graph():
                 "parent_id": 1,
                 "atomic": True,
                 "reusable": False,
-                "connection_type": "bolt",
+                "connection_type": 1,
                 "level": 1,
                 "weight": 1.0,
                 "recyclable": True,
@@ -148,7 +146,7 @@ def test_create_node():
             "parent_id": None,
             "atomic": True,
             "reusable": False,
-            "connection_type": "bolt",
+            "connection_type": 1,
             "level": 0,
             "weight": 1.0,
             "recyclable": True,
@@ -163,7 +161,7 @@ def test_create_node():
         "parent_id": None,
         "atomic": True,
         "reusable": False,
-        "connection_type": "bolt",
+        "connection_type": 1,
         "level": 0,
         "weight": 1.0,
         "recyclable": True,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,7 +17,7 @@ export default function App() {
     atomic: false,
     weight: 1,
     reusable: false,
-    connection_type: '',
+    connection_type: 0,
     material_id: '' as string | number,
   })
 
@@ -169,7 +169,7 @@ export default function App() {
           atomic: false,
           weight: 1,
           reusable: false,
-          connection_type: '',
+          connection_type: 0,
           material_id: '',
         })
       })
@@ -235,11 +235,16 @@ export default function App() {
               />
               Reusable
             </label>
-            <input
-              placeholder="Connection Type"
+            <select
               value={newNode.connection_type}
-              onChange={e => setNewNode({ ...newNode, connection_type: e.target.value })}
-            />
+              onChange={e =>
+                setNewNode({ ...newNode, connection_type: Number(e.target.value) })
+              }
+            >
+              {[0, 1, 2, 3, 4, 5].map(n => (
+                <option key={n} value={n}>{n}</option>
+              ))}
+            </select>
             <input
               type="number"
               placeholder="Material ID"

--- a/frontend/src/__tests__/wsMessage.test.ts
+++ b/frontend/src/__tests__/wsMessage.test.ts
@@ -22,7 +22,7 @@ describe('applyWsMessage', () => {
         atomic: true,
         weight: 3,
         reusable: false,
-        connection_type: 'bolted',
+        connection_type: 2,
         material_id: 5,
       },
     })
@@ -31,7 +31,7 @@ describe('applyWsMessage', () => {
     expect(n.level).toBe(1)
     expect(n.atomic).toBe(true)
     expect(n.weight).toBe(3)
-    expect(n.connection_type).toBe('bolted')
+    expect(n.connection_type).toBe(2)
   })
 
   it('ignores unknown op', () => {

--- a/frontend/src/wsMessage.ts
+++ b/frontend/src/wsMessage.ts
@@ -6,7 +6,7 @@ export interface Component {
   atomic?: boolean
   weight?: number
   reusable?: boolean
-  connection_type?: string
+  connection_type?: number
   material_id?: number
   position?: { x: number; y: number }
 }


### PR DESCRIPTION
## Summary
- validate connection_type as int range in backend
- adapt frontend components and state for numeric connection_type
- update tests for new connection_type type

## Testing
- `npm test --silent`
- `pytest -q`
- `ruff check backend/app`

------
https://chatgpt.com/codex/tasks/task_e_685163c09a448332807490bf3aa13a42