### PR TITLE
Implement conditional weight for nodes

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class MaterialBase(BaseModel):
@@ -28,8 +28,14 @@ class NodeBase(BaseModel):
     reusable: bool
     connection_type: str | None = None
     level: int
-    weight: float
+    weight: float | None = None
     recyclable: bool
+
+    @model_validator(mode="after")
+    def _check_weight_atomic(self) -> "NodeBase":
+        if self.atomic and self.weight is None:
+            raise ValueError("weight must be provided when node is atomic")
+        return self
 
 
 class NodeCreate(NodeBase):

--- a/backend/tests/test_projects.py
+++ b/backend/tests/test_projects.py
@@ -136,7 +136,7 @@ def test_get_graph():
     app.dependency_overrides.clear()
 
 
-def test_create_node():
+def test_create_node_atomic():
     app.dependency_overrides[get_write_session] = override_get_session_node
     client = TestClient(app)
     response = client.post(
@@ -168,4 +168,59 @@ def test_create_node():
         "weight": 1.0,
         "recyclable": True,
     }
+    app.dependency_overrides.clear()
+
+
+def test_create_node_non_atomic():
+    app.dependency_overrides[get_write_session] = override_get_session_node
+    client = TestClient(app)
+    response = client.post(
+        "/nodes/",
+        json={
+            "project_id": 1,
+            "material_id": 2,
+            "name": "Group",
+            "parent_id": None,
+            "atomic": False,
+            "reusable": False,
+            "connection_type": "bolt",
+            "level": 0,
+            "recyclable": True,
+        },
+    )
+    assert response.status_code == 200
+    assert response.json() == {
+        "id": 1,
+        "project_id": 1,
+        "material_id": 2,
+        "name": "Group",
+        "parent_id": None,
+        "atomic": False,
+        "reusable": False,
+        "connection_type": "bolt",
+        "level": 0,
+        "weight": None,
+        "recyclable": True,
+    }
+    app.dependency_overrides.clear()
+
+
+def test_atomic_weight_required():
+    app.dependency_overrides[get_write_session] = override_get_session_node
+    client = TestClient(app)
+    response = client.post(
+        "/nodes/",
+        json={
+            "project_id": 1,
+            "material_id": 2,
+            "name": "Child",
+            "parent_id": None,
+            "atomic": True,
+            "reusable": False,
+            "connection_type": "bolt",
+            "level": 0,
+            "recyclable": True,
+        },
+    )
+    assert response.status_code == 422
     app.dependency_overrides.clear()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -134,16 +134,18 @@ export default function App() {
 
   const handleNodeSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    const payload = {
+    const payload: any = {
       project_id: Number(projectId),
       name: newNode.name,
       level: Number(newNode.level),
       parent_id: newNode.parent_id === '' ? null : Number(newNode.parent_id),
       atomic: newNode.atomic,
-      weight: Number(newNode.weight),
       reusable: newNode.reusable,
       connection_type: newNode.connection_type,
       material_id: Number(newNode.material_id || 0),
+    }
+    if (newNode.atomic) {
+      payload.weight = Number(newNode.weight)
     }
     fetch('/nodes/', {
       method: 'POST',
@@ -224,7 +226,7 @@ export default function App() {
               step="any"
               placeholder="Weight"
               value={newNode.weight}
-              disabled={newNode.atomic}
+              disabled={!newNode.atomic}
               onChange={e => setNewNode({ ...newNode, weight: Number(e.target.value) })}
             />
             <label className="block">

--- a/frontend/src/__tests__/wsMessage.test.ts
+++ b/frontend/src/__tests__/wsMessage.test.ts
@@ -34,6 +34,25 @@ describe('applyWsMessage', () => {
     expect(n.connection_type).toBe('bolted')
   })
 
+  it('omits weight for non atomic node', () => {
+    const state: GraphState = { nodes: [], edges: [], materials: [] }
+    const result = applyWsMessage(state, {
+      op: 'create_node',
+      node: {
+        id: 3,
+        name: 'Group',
+        level: 0,
+        parent_id: null,
+        atomic: false,
+        reusable: false,
+        connection_type: 'bolt',
+      },
+    })
+    const n = result.nodes[0]
+    expect(n.atomic).toBe(false)
+    expect(n.weight).toBeUndefined()
+  })
+
   it('ignores unknown op', () => {
     const state: GraphState = { nodes: [], edges: [], materials: [] }
     const result = applyWsMessage(state, { op: 'unknown', foo: 'bar' })


### PR DESCRIPTION
## Summary
- allow nullable NodeBase.weight
- validate atomic nodes require a weight
- exclude weight when creating non-atomic nodes
- skip weight in frontend when atomic=false
- expand node tests for both atomic and non-atomic cases

## Testing
- `ruff check .`
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685163c644a88332a9101a888aeaf8a6