### PR TITLE
Allow string connection types

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -7,11 +7,13 @@ from pydantic import BaseModel, Field, model_validator
 # Materials
 # ---------------------------------------------------------------------------
 
+
 class MaterialBase(BaseModel):
     name: str = Field(..., example="Aluminum")
     weight: float = Field(..., gt=0)
     co2_value: float = Field(..., gt=0)
-    hardness: float = Field(..., gt=0)           # kept from Development_Nachhaltigkeit
+    hardness: float = Field(..., gt=0)  # kept from Development_Nachhaltigkeit
+
 
 class MaterialCreate(MaterialBase):
     pass
@@ -28,6 +30,7 @@ class Material(MaterialBase):
 # Nodes
 # ---------------------------------------------------------------------------
 
+
 class NodeBase(BaseModel):
     project_id: int
     material_id: int
@@ -35,7 +38,7 @@ class NodeBase(BaseModel):
     parent_id: int | None = None
     atomic: bool
     reusable: bool
-    connection_type: int | None = Field(None, ge=0, le=5)
+    connection_type: str | int | None = None
     level: int
     weight: float | None = None
     recyclable: bool
@@ -45,6 +48,18 @@ class NodeBase(BaseModel):
         """If a node is atomic it must carry its own weight."""
         if self.atomic and self.weight is None:
             raise ValueError("weight must be provided when node is atomic")
+        return self
+
+    @model_validator(mode="after")
+    def _validate_connection_type(self) -> "NodeBase":
+        """Ensure connection_type is either within range when numeric or any string."""
+        if isinstance(self.connection_type, int):
+            if not 0 <= self.connection_type <= 5:
+                raise ValueError("connection_type numeric must be between 0 and 5")
+        elif self.connection_type is not None and not isinstance(
+            self.connection_type, str
+        ):
+            raise ValueError("connection_type must be int, str, or None")
         return self
 
 
@@ -62,6 +77,7 @@ class Node(NodeBase):
 # ---------------------------------------------------------------------------
 # Relations
 # ---------------------------------------------------------------------------
+
 
 class RelationBase(BaseModel):
     project_id: int
@@ -84,6 +100,7 @@ class Relation(RelationBase):
 # Projects
 # ---------------------------------------------------------------------------
 
+
 class ProjectBase(BaseModel):
     name: str
 
@@ -102,6 +119,7 @@ class Project(ProjectBase):
 # ---------------------------------------------------------------------------
 # Sustainability score tracking (from implement-sustainability-score-tracking)
 # ---------------------------------------------------------------------------
+
 
 class NodeScore(BaseModel):
     id: int

--- a/backend/app/routers/score.py
+++ b/backend/app/routers/score.py
@@ -23,7 +23,10 @@ async def score_project(
         raise HTTPException(status_code=503, detail="Neo4j unavailable")
     records = await result.data()
 
-    def factor(ctype: str | None) -> float:
+    def factor(ctype: str | int | None) -> float:
+        mapping = {0: "screw", 1: "bolt", 2: "glue"}
+        if isinstance(ctype, int):
+            ctype = mapping.get(ctype)
         return {"screw": 0.8, "bolt": 1.0, "glue": 1.2}.get(ctype or "", 1.0)
 
     scores: list[NodeScore] = []

--- a/backend/tests/test_projects.py
+++ b/backend/tests/test_projects.py
@@ -12,6 +12,7 @@ from app.database import get_session, get_write_session
 # Helpers & fake Neo4j sessions
 # ---------------------------------------------------------------------------
 
+
 class FakeResult:
     def __init__(self, record):
         self._record = record
@@ -30,14 +31,46 @@ class FakeResultList:
 
 class FakeSession:
     """Write session for project creation."""
+
     async def run(self, query, **params):
         return FakeResult({"id": 1, "name": params["name"]})
 
 
 class FakeSessionNode:
     """Write session for node creation."""
+
     async def run(self, query, **params):
         return FakeResult({"id": 1})
+
+
+class FakeSessionScore:
+    """Session for scoring projects."""
+
+    def __init__(self):
+        self._first = True
+
+    async def run(self, query, **params):
+        if "RETURN id(n) AS nid" in query:
+            return FakeResultList(
+                [
+                    {
+                        "nid": 1,
+                        "co2": 2.0,
+                        "weight": 1.0,
+                        "ctype": 1,
+                        "reusable": False,
+                    },
+                    {
+                        "nid": 2,
+                        "co2": 1.0,
+                        "weight": 2.0,
+                        "ctype": "bolt",
+                        "reusable": True,
+                    },
+                ]
+            )
+        else:
+            return FakeResult(None)
 
 
 class FakeSessionGraph:
@@ -47,106 +80,119 @@ class FakeSessionGraph:
       • call 2 → edges
       • call 3 → materials
     """
+
     def __init__(self):
         self._calls = 0
 
     async def run(self, query, **params):
         self._calls += 1
-        if self._calls == 1:            # nodes
-            return FakeResultList([
-                {
-                    "id": 1,
-                    "material_id": 2,
-                    "name": "Parent",
-                    "parent_id": None,
-                    "atomic": False,
-                    "reusable": False,
-                    "connection_type": 1,
-                    "level": 0,
-                    "weight": 1.0,      # matches test expectation
-                    "recyclable": True,
-                },
-                {
-                    "id": 2,
-                    "material_id": 3,
-                    "name": "Child",
-                    "parent_id": 1,
-                    "atomic": True,
-                    "reusable": False,
-                    "connection_type": 1,
-                    "level": 1,
-                    "weight": 1.0,
-                    "recyclable": True,
-                },
-            ])
-        elif self._calls == 2:          # edges
+        if self._calls == 1:  # nodes
+            return FakeResultList(
+                [
+                    {
+                        "id": 1,
+                        "material_id": 2,
+                        "name": "Parent",
+                        "parent_id": None,
+                        "atomic": False,
+                        "reusable": False,
+                        "connection_type": 1,
+                        "level": 0,
+                        "weight": 1.0,  # matches test expectation
+                        "recyclable": True,
+                    },
+                    {
+                        "id": 2,
+                        "material_id": 3,
+                        "name": "Child",
+                        "parent_id": 1,
+                        "atomic": True,
+                        "reusable": False,
+                        "connection_type": 1,
+                        "level": 1,
+                        "weight": 1.0,
+                        "recyclable": True,
+                    },
+                ]
+            )
+        elif self._calls == 2:  # edges
             return FakeResultList([{"id": 10, "source": 1, "target": 2}])
-        else:                           # materials
-            return FakeResultList([
-                {
-                    "id": 2,
-                    "name": "Steel",
-                    "weight": 7.8,
-                    "co2_value": 1.0,
-                    "hardness": 10.0,
-                }
-            ])
+        else:  # materials
+            return FakeResultList(
+                [
+                    {
+                        "id": 2,
+                        "name": "Steel",
+                        "weight": 7.8,
+                        "co2_value": 1.0,
+                        "hardness": 10.0,
+                    }
+                ]
+            )
 
 
 class FakeSessionGraphCycle:
     """Same pattern as above, but returns a graph with a cycle so the endpoint errors."""
+
     def __init__(self):
         self._calls = 0
 
     async def run(self, query, **params):
         self._calls += 1
-        if self._calls == 1:            # nodes
-            return FakeResultList([
-                {
-                    "id": 1,
-                    "material_id": 2,
-                    "name": "A",
-                    "parent_id": 2,
-                    "atomic": False,
-                    "reusable": False,
-                    "connection_type": 1,
-                    "level": 0,
-                    "weight": 0.0,
-                    "recyclable": True,
-                },
-                {
-                    "id": 2,
-                    "material_id": 2,
-                    "name": "B",
-                    "parent_id": 1,
-                    "atomic": False,
-                    "reusable": False,
-                    "connection_type": 1,
-                    "level": 1,
-                    "weight": 0.0,
-                    "recyclable": True,
-                },
-            ])
-        elif self._calls == 2:          # edges (cycle present)
-            return FakeResultList([
-                {"id": 10, "source": 1, "target": 2},
-                {"id": 11, "source": 2, "target": 1},
-            ])
-        else:                           # materials
-            return FakeResultList([
-                {
-                    "id": 2,
-                    "name": "Steel",
-                    "weight": 7.8,
-                    "co2_value": 1.0,
-                    "hardness": 10.0,
-                }
-            ])
+        if self._calls == 1:  # nodes
+            return FakeResultList(
+                [
+                    {
+                        "id": 1,
+                        "material_id": 2,
+                        "name": "A",
+                        "parent_id": 2,
+                        "atomic": False,
+                        "reusable": False,
+                        "connection_type": 1,
+                        "level": 0,
+                        "weight": 0.0,
+                        "recyclable": True,
+                    },
+                    {
+                        "id": 2,
+                        "material_id": 2,
+                        "name": "B",
+                        "parent_id": 1,
+                        "atomic": False,
+                        "reusable": False,
+                        "connection_type": 1,
+                        "level": 1,
+                        "weight": 0.0,
+                        "recyclable": True,
+                    },
+                ]
+            )
+        elif self._calls == 2:  # edges (cycle present)
+            return FakeResultList(
+                [
+                    {"id": 10, "source": 1, "target": 2},
+                    {"id": 11, "source": 2, "target": 1},
+                ]
+            )
+        else:  # materials
+            return FakeResultList(
+                [
+                    {
+                        "id": 2,
+                        "name": "Steel",
+                        "weight": 7.8,
+                        "co2_value": 1.0,
+                        "hardness": 10.0,
+                    }
+                ]
+            )
 
 
 # ---------------------------------------------------------------------------
 # Dependency overrides
 # ---------------------------------------------------------------------------
+
 
 async def override_get_session():
     yield FakeSession()
@@ -164,9 +210,14 @@ async def override_get_session_node():
     yield FakeSessionNode()
 
 
+async def override_get_session_score():
+    yield FakeSessionScore()
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
 
 def test_create_project():
     app.dependency_overrides[get_write_session] = override_get_session
@@ -327,4 +378,18 @@ def test_atomic_weight_required():
         },
     )
     assert response.status_code == 422
+    app.dependency_overrides.clear()
+
+
+def test_score_project_mixed_connection_types():
+    app.dependency_overrides[get_write_session] = override_get_session_score
+    client = TestClient(app)
+
+    response = client.post("/score/1")
+    assert response.status_code == 200
+    assert response.json() == [
+        {"id": 1, "sustainability_score": 2.0},
+        {"id": 2, "sustainability_score": 1.0},
+    ]
+
     app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- allow `connection_type` to be a string
- map numeric connection types to string names when calculating score
- extend tests with score endpoint check

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `black --check app/models/schemas.py app/routers/score.py tests/test_projects.py`

------
https://chatgpt.com/codex/tasks/task_e_68516c2df85c8332aa210d0f5679095f