### PR TITLE
Enforce positive node weight

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -37,7 +37,7 @@ class NodeBase(BaseModel):
     reusable: bool
     connection_type: int | None = Field(None, ge=0, le=5)
     level: int
-    weight: float | None = None
+    weight: float | None = Field(None, gt=0)
     recyclable: bool
 
     @model_validator(mode="after")

--- a/backend/tests/test_projects.py
+++ b/backend/tests/test_projects.py
@@ -287,7 +287,7 @@ def test_create_node_non_atomic():
             "parent_id": None,
             "atomic": False,
             "reusable": False,
-            "connection_type": "bolt",
+            "connection_type": 1,
             "level": 0,
             "recyclable": True,
         },
@@ -301,7 +301,7 @@ def test_create_node_non_atomic():
         "parent_id": None,
         "atomic": False,
         "reusable": False,
-        "connection_type": "bolt",
+        "connection_type": 1,
         "level": 0,
         "weight": None,
         "recyclable": True,
@@ -321,8 +321,52 @@ def test_atomic_weight_required():
             "parent_id": None,
             "atomic": True,
             "reusable": False,
-            "connection_type": "bolt",
+            "connection_type": 1,
             "level": 0,
+            "recyclable": True,
+        },
+    )
+    assert response.status_code == 422
+    app.dependency_overrides.clear()
+
+
+def test_negative_weight():
+    app.dependency_overrides[get_write_session] = override_get_session_node
+    client = TestClient(app)
+    response = client.post(
+        "/nodes/",
+        json={
+            "project_id": 1,
+            "material_id": 2,
+            "name": "Child",
+            "parent_id": None,
+            "atomic": True,
+            "reusable": False,
+            "connection_type": 1,
+            "level": 0,
+            "weight": -1.0,
+            "recyclable": True,
+        },
+    )
+    assert response.status_code == 422
+    app.dependency_overrides.clear()
+
+
+def test_zero_weight():
+    app.dependency_overrides[get_write_session] = override_get_session_node
+    client = TestClient(app)
+    response = client.post(
+        "/nodes/",
+        json={
+            "project_id": 1,
+            "material_id": 2,
+            "name": "Child",
+            "parent_id": None,
+            "atomic": True,
+            "reusable": False,
+            "connection_type": 1,
+            "level": 0,
+            "weight": 0,
             "recyclable": True,
         },
     )


### PR DESCRIPTION
## Summary
- validate node `weight` is positive when provided
- update tests for integer `connection_type`
- add tests for negative and zero weights

## Testing
- `ruff check backend`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68516c6910e08332b1b2cd1f73b84973