### PR TITLE
Add numeric edge id tests

### DIFF
--- a/frontend/src/__tests__/wsMessage.test.ts
+++ b/frontend/src/__tests__/wsMessage.test.ts
@@ -14,4 +14,28 @@ describe('applyWsMessage', () => {
     const result = applyWsMessage(state, { op: 'unknown', foo: 'bar' })
     expect(result).toEqual(state)
   })
+
+  it('stores numeric ids for create_relation', () => {
+    const state: GraphState = { nodes: [], edges: [], materials: [] }
+    const result = applyWsMessage(state, {
+      op: 'create_relation',
+      id: '2',
+      source: '1',
+      target: '3',
+    })
+    expect(typeof result.edges[0].id).toBe('number')
+    expect(result.edges[0]).toEqual({ id: 2, source: 1, target: 3 })
+  })
+
+  it('keeps numeric ids when provided as numbers', () => {
+    const state: GraphState = { nodes: [], edges: [], materials: [] }
+    const result = applyWsMessage(state, {
+      op: 'create_relation',
+      id: 4,
+      source: 1,
+      target: 2,
+    })
+    expect(typeof result.edges[0].id).toBe('number')
+    expect(result.edges[0]).toEqual({ id: 4, source: 1, target: 2 })
+  })
 })

--- a/frontend/src/wsMessage.ts
+++ b/frontend/src/wsMessage.ts
@@ -24,14 +24,25 @@ export function applyWsMessage(state: GraphState, msg: WsMessage): GraphState {
         return { ...state, nodes: state.nodes.filter(n => n.id !== msg.id) }
       }
       return state
-    case 'create_relation':
-      if ('id' in msg && 'source' in msg && 'target' in msg) {
-        return { ...state, edges: [...state.edges, { id: msg.id, source: msg.source, target: msg.target }] }
-      }
+      case 'create_relation':
+        if ('id' in msg && 'source' in msg && 'target' in msg) {
+          return {
+            ...state,
+            edges: [
+              ...state.edges,
+              {
+                id: Number(msg.id),
+                source: Number(msg.source),
+                target: Number(msg.target),
+              },
+            ],
+          }
+        }
       return state
     case 'delete_relation':
       if ('id' in msg) {
-        return { ...state, edges: state.edges.filter(e => e.id !== msg.id) }
+        const id = Number(msg.id)
+        return { ...state, edges: state.edges.filter(e => e.id !== id) }
       }
       return state
     case 'create_material':


### PR DESCRIPTION
## Summary
- verify relation IDs are stored as numbers in frontend state
- ensure IDs parsed as numbers in applyWsMessage

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68516fdc30e48332b2be1298de537d78