### PR TITLE
Fix project score test for glue factor

### DIFF
--- a/backend/tests/test_projects.py
+++ b/backend/tests/test_projects.py
@@ -480,7 +480,7 @@ def test_score_project_mixed_connection_types():
     assert response.status_code == 200
     assert response.json() == [
         {"id": 1, "sustainability_score": 2.0},
-        {"id": 2, "sustainability_score": 1.0},
+        {"id": 2, "sustainability_score": 1.2},
     ]
 
     app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- update expected score for glue connections in `test_score_project_mixed_connection_types`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685185260d3c8332b0b1feae495784d5