### PR TITLE
Validate parent node on creation

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -67,6 +67,15 @@ class NodeBase(BaseModel):
             raise ValueError("connection_type must be int, str, or None")
         return self
 
+    @model_validator(mode="after")
+    def _validate_parent_id(self) -> "NodeBase":
+        """Validate combination of ``parent_id`` and ``level``."""
+        if self.level == 0 and self.parent_id is not None:
+            raise ValueError("parent_id must be None when level is 0")
+        if self.level > 0 and self.parent_id is None:
+            raise ValueError("parent_id must be provided when level > 0")
+        return self
+
 
 class NodeCreate(NodeBase):
     pass


### PR DESCRIPTION
## Summary
- validate parent_id/level combinations in schemas
- ensure parent node exists in project when creating nodes
- test bad parent_id combinations and missing parent cases

## Testing
- `ruff check backend`
- `pytest -q` *(fails: test_score_project_mixed_connection_types)*

------
https://chatgpt.com/codex/tasks/task_e_685185069fa883329eb533767d635cf2