### PR TITLE
Map GraphCanvas props to ReactFlow format

### DIFF
--- a/frontend/src/components/GraphCanvas.tsx
+++ b/frontend/src/components/GraphCanvas.tsx
@@ -1,5 +1,12 @@
 import React from 'react'
-import ReactFlow, { MiniMap, Controls, Background, Connection } from 'reactflow'
+import ReactFlow, {
+  MiniMap,
+  Controls,
+  Background,
+  Connection,
+  Node as RFNode,
+  Edge as RFEdge,
+} from 'reactflow'
 import 'reactflow/dist/style.css'
 
 
@@ -10,10 +17,21 @@ interface Props {
 }
 
 export default function GraphCanvas({ nodes, edges, onConnectEdge }: Props) {
+  const rfNodes: RFNode[] = nodes.map((n) => ({
+    id: String(n.id),
+    position: n.position ?? { x: 0, y: 0 },
+    data: { label: n.name ?? String(n.id) },
+  }))
+  const rfEdges: RFEdge[] = edges.map((e) => ({
+    id: String(e.id),
+    source: String(e.source),
+    target: String(e.target),
+  }))
+
   return (
     <ReactFlow
-      nodes={nodes}
-      edges={edges}
+      nodes={rfNodes}
+      edges={rfEdges}
       onConnect={onConnectEdge}
       fitView
       style={{ width: '100%', height: '100%' }}


### PR DESCRIPTION
## Summary
- map nodes/edges to ReactFlow compatible objects in `GraphCanvas`
- import `Node` and `Edge` types from `reactflow`

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d52f017b88332b98d0cddb62bcd10