### PR TITLE
Remove unnecessary state update

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -44,15 +44,15 @@ class Material(MaterialBase):
 class NodeBase(BaseModel):
     project_id: int
     material_id: int
-    name: str
+    name: str = ''
     parent_id: int | None = None
-    atomic: bool
-    reusable: bool
+    atomic: bool = False
+    reusable: bool = False
     # allow both Enum values and custom string identifiers
     connection_type: ConnectionType | str | None = None
-    level: int
+    level: int = 0
     weight: float | None = Field(None, gt=0)
-    recyclable: bool
+    recyclable: bool = False
 
     # ---- Validators -------------------------------------------------------
 

--- a/backend/app/routers/score.py
+++ b/backend/app/routers/score.py
@@ -28,7 +28,7 @@ async def score_project(
     )
 
     result = await session.execute(join_stmt)
-    records = [dict(row) for row in result]
+    records = [dict(row._mapping) for row in result]
 
     factor_map = {
         ConnectionType.SCREW: 0.8,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -252,7 +252,7 @@ export default function App() {
       }
 
       const node = await response.json()
-      setState((prev) => applyWsMessage(prev, { op: 'create_node', node }))
+      // WebSocket broadcast will create the node in local state
     } catch (err) {
       console.error(err)
       setError('Failed to create node')


### PR DESCRIPTION
## Summary
- avoid updating state locally when creating nodes
- default optional fields for nodes in backend schemas
- fix SQLAlchemy row handling in score router

## Testing
- `npm test --silent`
- `pytest -q`
- `flake8` *(fails: F401/E402)*

------
https://chatgpt.com/codex/tasks/task_e_685d53000428833280bf53cc33484e07