### PR TITLE
Add deletion UI for nodes, edges, and materials

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useRef } from 'react'
 import GraphCanvas from './components/GraphCanvas'
 import ComponentTable from './components/ComponentTable'
+import MaterialTable from './components/MaterialTable'
 import useUndoRedo from './components/useUndoRedo'
 import { applyWsMessage, GraphState, WsMessage, Component } from './wsMessage'
 
@@ -223,6 +224,18 @@ export default function App() {
       .catch((err) => console.error(err))
   }
 
+  const deleteNode = (id: number) => {
+    fetch(`/nodes/${id}`, { method: 'DELETE' }).catch((err) => console.error(err))
+  }
+
+  const deleteEdge = (id: number) => {
+    fetch(`/relations/${id}`, { method: 'DELETE' }).catch((err) => console.error(err))
+  }
+
+  const deleteMaterial = (id: number) => {
+    fetch(`/materials/${id}`, { method: 'DELETE' }).catch((err) => console.error(err))
+  }
+
   /* --------------------------------------------------------------------- */
   /*  7️⃣  Handle node creation                                             */
   /* --------------------------------------------------------------------- */
@@ -315,7 +328,13 @@ export default function App() {
     <div className="flex h-full w-full">
       {/* ----------------------------------------------------------------- */}
       <div className="w-2/3 h-full">
-        <GraphCanvas nodes={state.nodes} edges={state.edges} onConnectEdge={handleConnect} />
+        <GraphCanvas
+          nodes={state.nodes}
+          edges={state.edges}
+          onConnectEdge={handleConnect}
+          onDeleteNodes={(ids) => ids.forEach(deleteNode)}
+          onDeleteEdges={(ids) => ids.forEach(deleteEdge)}
+        />
 
         {/* ----------------------- Create node overlay -------------------- */}
         {showNodeForm && (
@@ -470,6 +489,7 @@ export default function App() {
       {/* ----------------------------------------------------------------- */}
       <div className="w-1/3 h-full overflow-auto border-l">
         <ComponentTable components={state.nodes} />
+        <MaterialTable materials={state.materials} onDelete={deleteMaterial} />
       </div>
     </div>
   )

--- a/frontend/src/__tests__/wsMessage.test.ts
+++ b/frontend/src/__tests__/wsMessage.test.ts
@@ -99,4 +99,34 @@ describe('applyWsMessage', () => {
     expect(typeof result.edges[0].id).toBe('number')
     expect(result.edges[0]).toEqual({ id: 4, source: 1, target: 2 })
   })
+
+  it('removes a node for delete_node', () => {
+    const state: GraphState = {
+      nodes: [{ id: 1 }],
+      edges: [],
+      materials: [],
+    }
+    const result = applyWsMessage(state, { op: 'delete_node', id: 1 })
+    expect(result.nodes).toHaveLength(0)
+  })
+
+  it('removes a relation for delete_relation', () => {
+    const state: GraphState = {
+      nodes: [],
+      edges: [{ id: 1, source: 1, target: 2 }],
+      materials: [],
+    }
+    const result = applyWsMessage(state, { op: 'delete_relation', id: 1 })
+    expect(result.edges).toHaveLength(0)
+  })
+
+  it('removes a material for delete_material', () => {
+    const state: GraphState = {
+      nodes: [],
+      edges: [],
+      materials: [{ id: 5 }],
+    }
+    const result = applyWsMessage(state, { op: 'delete_material', id: 5 })
+    expect(result.materials).toHaveLength(0)
+  })
 })

--- a/frontend/src/components/GraphCanvas.tsx
+++ b/frontend/src/components/GraphCanvas.tsx
@@ -14,9 +14,17 @@ interface Props {
   nodes: any[]
   edges: any[]
   onConnectEdge: (connection: Connection) => void
+  onDeleteNodes?: (ids: number[]) => void
+  onDeleteEdges?: (ids: number[]) => void
 }
 
-export default function GraphCanvas({ nodes, edges, onConnectEdge }: Props) {
+export default function GraphCanvas({
+  nodes,
+  edges,
+  onConnectEdge,
+  onDeleteNodes = () => {},
+  onDeleteEdges = () => {},
+}: Props) {
   const rfNodes: RFNode[] = nodes.map((n) => ({
     id: String(n.id),
     position: n.position ?? { x: 0, y: 0 },
@@ -33,6 +41,8 @@ export default function GraphCanvas({ nodes, edges, onConnectEdge }: Props) {
       nodes={rfNodes}
       edges={rfEdges}
       onConnect={onConnectEdge}
+      onNodesDelete={nds => onDeleteNodes(nds.map(n => Number(n.id)))}
+      onEdgesDelete={eds => onDeleteEdges(eds.map(e => Number(e.id)))}
       fitView
       style={{ width: '100%', height: '100%' }}
     >


### PR DESCRIPTION
## Summary
- extend `GraphCanvas` with callbacks for node/edge deletion
- add deletion handlers and Material table to the React app
- cover delete actions in `applyWsMessage` tests

## Testing
- `flake8`
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d5c24d49883329395be349f3316b3