### PR TITLE
Filter parent candidates by node level

### DIFF
--- a/frontend/src/__tests__/filterParentCandidates.test.ts
+++ b/frontend/src/__tests__/filterParentCandidates.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+import filterParentCandidates from '../filterParentCandidates'
+import type { Component } from '../wsMessage'
+
+describe('filterParentCandidates', () => {
+  it('returns nodes whose level equals level - 1', () => {
+    const nodes: Component[] = [
+      { id: 1, level: 0 },
+      { id: 2, level: 1 },
+      { id: 3, level: 2 },
+    ]
+    expect(filterParentCandidates(nodes, 2)).toEqual([{ id: 2, level: 1 }])
+  })
+
+  it('handles missing level as 0', () => {
+    const nodes: Component[] = [{ id: 1 }, { id: 2, level: 1 }]
+    expect(filterParentCandidates(nodes, 1)).toEqual([{ id: 1 }])
+  })
+})

--- a/frontend/src/filterParentCandidates.ts
+++ b/frontend/src/filterParentCandidates.ts
@@ -1,0 +1,5 @@
+import { Component } from './wsMessage'
+
+export default function filterParentCandidates(nodes: Component[], level: number): Component[] {
+  return nodes.filter(n => (n.level ?? 0) === level - 1)
+}


### PR DESCRIPTION
## Summary
- add `filterParentCandidates` helper
- filter available parent list when level changes
- update parent selector rendering and handler
- test filtering helper

## Testing
- `npm run test`
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d60faeea88332a1ae34cc3016d7d4