### PR TITLE
Add automatic parent-child edges

### DIFF
--- a/backend/app/routers/nodes.py
+++ b/backend/app/routers/nodes.py
@@ -77,8 +77,18 @@ async def create_node(
         "recyclable": node.recyclable,
     }
 
-    # Broadcasten und zurückgeben
+    # Broadcasten und Relation erzeugen, falls Parent vorhanden ist
     await broadcast(node.project_id, {"op": "create_node", "node": node_data})
+    if node.parent_id is not None:
+        await broadcast(
+            node.project_id,
+            {
+                "op": "create_relation",
+                "id": -db_obj.id,
+                "source": node.parent_id,
+                "target": db_obj.id,
+            },
+        )
     return Node(**node_data)
 
 

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -89,11 +89,24 @@ async def get_graph(
         )
 
     # 2) Edges
-    result_edges = await session.execute(select(RelationModel).where(RelationModel.project_id == project_id))
+    result_edges = await session.execute(
+        select(RelationModel).where(RelationModel.project_id == project_id)
+    )
     edges = [
         {"id": rel.id, "source": rel.source_id, "target": rel.target_id}
         for rel in result_edges.scalars()
     ]
+
+    # add edges for parent-child relations using negative ids
+    for n in nodes:
+        if n["parent_id"] is not None:
+            edges.append(
+                {
+                    "id": -n["id"],
+                    "source": n["parent_id"],
+                    "target": n["id"],
+                }
+            )
 
     # 3) Materials
     res_mats = await session.execute(select(MaterialModel))

--- a/backend/tests/test_graph_edges.py
+++ b/backend/tests/test_graph_edges.py
@@ -1,0 +1,85 @@
+import os
+os.environ["TESTING"] = "1"
+
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+
+from app import app as fastapi_app
+from app.database import get_session, get_write_session
+from app.models.db import Base
+
+import pytest
+
+
+@pytest.fixture()
+def client():
+    database_url = "sqlite+aiosqlite:///:memory:"
+    engine = create_async_engine(database_url, future=True)
+    SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+
+    async def override_get_session(*, write: bool = False):
+        async with SessionLocal() as session:
+            yield session
+
+    async def override_get_write_session():
+        async for s in override_get_session(write=True):
+            yield s
+
+    fastapi_app.dependency_overrides[get_session] = override_get_session
+    fastapi_app.dependency_overrides[get_write_session] = override_get_write_session
+
+    async def init_models():
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+    import asyncio
+    asyncio.get_event_loop().run_until_complete(init_models())
+
+    with TestClient(fastapi_app) as c:
+        yield c
+
+    fastapi_app.dependency_overrides.clear()
+    import asyncio
+    asyncio.get_event_loop().run_until_complete(engine.dispose())
+
+
+def test_parent_edge_in_graph(client):
+    client.post("/projects/", json={"name": "Demo"})
+    client.post(
+        "/materials/",
+        json={"name": "Steel", "weight": 1.0, "co2_value": 1.0, "hardness": 1.0},
+    )
+    # root node
+    client.post(
+        "/nodes/",
+        json={
+            "project_id": 1,
+            "material_id": 1,
+            "name": "Root",
+            "parent_id": None,
+            "atomic": False,
+            "reusable": False,
+            "connection_type": 0,
+            "level": 0,
+            "recyclable": True,
+        },
+    )
+    # child node
+    res = client.post(
+        "/nodes/",
+        json={
+            "project_id": 1,
+            "material_id": 1,
+            "name": "Child",
+            "parent_id": 1,
+            "atomic": True,
+            "reusable": False,
+            "connection_type": 0,
+            "level": 1,
+            "weight": 2.0,
+            "recyclable": True,
+        },
+    )
+    nid = res.json()["id"]
+    graph = client.get("/projects/1/graph").json()
+    assert {"id": -nid, "source": 1, "target": nid} in graph["edges"]
+

--- a/frontend/src/__tests__/wsMessage.test.ts
+++ b/frontend/src/__tests__/wsMessage.test.ts
@@ -100,6 +100,17 @@ describe('applyWsMessage', () => {
     expect(result.edges[0]).toEqual({ id: 4, source: 1, target: 2 })
   })
 
+  it('supports negative ids for create_relation', () => {
+    const state: GraphState = { nodes: [], edges: [], materials: [] }
+    const result = applyWsMessage(state, {
+      op: 'create_relation',
+      id: -3,
+      source: 1,
+      target: 2,
+    })
+    expect(result.edges[0]).toEqual({ id: -3, source: 1, target: 2 })
+  })
+
   it('removes a node for delete_node', () => {
     const state: GraphState = {
       nodes: [{ id: 1 }],


### PR DESCRIPTION
## Summary
- add parent-child edges in `get_graph`
- broadcast create_relation on node creation when parent exists
- support negative relation IDs in frontend reducer
- test new behavior in backend and frontend

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685d60fd49748332aae21845f1ef5ede