### PR TITLE
Enforce node level hierarchy

### DIFF
--- a/backend/app/routers/materials.py
+++ b/backend/app/routers/materials.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select, delete
+from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError
 
 from .websocket import broadcast

--- a/backend/app/routers/nodes.py
+++ b/backend/app/routers/nodes.py
@@ -6,7 +6,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from .websocket import broadcast
 from ..database import get_session, get_write_session
 from ..models.schemas import Node, NodeCreate, ConnectionType
-from ..models.db import Node as NodeModel, Project as ProjectModel
+from ..models.db import Node as NodeModel
 
 router = APIRouter(prefix="/nodes", tags=["nodes"])
 
@@ -16,16 +16,19 @@ async def create_node(
     node: NodeCreate,
     session: AsyncSession = Depends(get_write_session),
 ):
-    # Prüfe, ob der Parent im gleichen Projekt existiert
+    # Prüfe, ob der Parent im gleichen Projekt existiert und ermittle dessen Level
     if node.parent_id is not None:
         res = await session.execute(
-            select(NodeModel.id).where(
+            select(NodeModel.level).where(
                 NodeModel.id == node.parent_id,
                 NodeModel.project_id == node.project_id,
             )
         )
-        if res.scalar_one_or_none() is None:
+        parent_level = res.scalar_one_or_none()
+        if parent_level is None:
             raise HTTPException(status_code=404, detail="Parent node not found")
+        if node.level != parent_level + 1:
+            raise HTTPException(status_code=400, detail="Invalid node level")
 
     # Verarbeite connection_type in DB-Wert und Response-String
     ctype_db = node.connection_type

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -6,9 +6,9 @@ from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
 
 os.environ["TESTING"] = "1"
 
-from app import app as fastapi_app
-from app.database import get_session, get_write_session
-from app.models.db import Base
+from app import app as fastapi_app  # noqa: E402
+from app.database import get_session, get_write_session  # noqa: E402
+from app.models.db import Base  # noqa: E402
 
 
 @pytest.fixture()
@@ -170,4 +170,66 @@ def test_finalize_project(client):
     data = res.json()
     root_node = next(n for n in data if n["id"] == 1)
     assert root_node["weight"] == 5.0
+
+
+def test_child_level_validation(client):
+    client.post("/projects/", json={"name": "Demo"})
+    client.post(
+        "/materials/",
+        json={"name": "Steel", "weight": 1.0, "co2_value": 1.0, "hardness": 1.0},
+    )
+
+    # root node
+    res = client.post(
+        "/nodes/",
+        json={
+            "project_id": 1,
+            "material_id": 1,
+            "name": "Root",
+            "parent_id": None,
+            "atomic": True,
+            "reusable": False,
+            "connection_type": 0,
+            "level": 0,
+            "weight": 1.0,
+            "recyclable": True,
+        },
+    )
+    assert res.status_code == 200
+
+    # valid child (level 1)
+    res = client.post(
+        "/nodes/",
+        json={
+            "project_id": 1,
+            "material_id": 1,
+            "name": "Child",
+            "parent_id": 1,
+            "atomic": True,
+            "reusable": False,
+            "connection_type": 0,
+            "level": 1,
+            "weight": 1.0,
+            "recyclable": True,
+        },
+    )
+    assert res.status_code == 200
+
+    # invalid child (level mismatch)
+    res = client.post(
+        "/nodes/",
+        json={
+            "project_id": 1,
+            "material_id": 1,
+            "name": "BadChild",
+            "parent_id": 1,
+            "atomic": True,
+            "reusable": False,
+            "connection_type": 0,
+            "level": 2,
+            "weight": 1.0,
+            "recyclable": True,
+        },
+    )
+    assert res.status_code == 400
 

--- a/backend/tests/test_nodes.py
+++ b/backend/tests/test_nodes.py
@@ -2,10 +2,10 @@ import os
 
 os.environ["TESTING"] = "1"
 
-import pytest
-from pydantic import ValidationError
+import pytest  # noqa: E402
+from pydantic import ValidationError  # noqa: E402
 
-from app.models.schemas import NodeCreate
+from app.models.schemas import NodeCreate  # noqa: E402
 
 
 def test_level_zero_no_parent_ok():


### PR DESCRIPTION
## Summary
- enforce parent-level check when creating nodes
- test node creation against invalid level combinations
- fix style issues

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d60f848748332b982470e09069583