### PR TITLE
Fix websocket broadcast for global material updates

### DIFF
--- a/backend/app/routers/websocket.py
+++ b/backend/app/routers/websocket.py
@@ -7,7 +7,18 @@ connections: dict[int, list[WebSocket]] = {}
 
 
 async def broadcast(project_id: int, message: dict):
-    for ws in connections.get(project_id, []):
+    """Send ``message`` to all sockets for ``project_id``.
+
+    The special ID ``0`` broadcasts to every connected client.
+    """
+    targets = []
+    if project_id == 0:
+        for lst in connections.values():
+            targets.extend(lst)
+    else:
+        targets = connections.get(project_id, [])
+
+    for ws in targets:
         await ws.send_json(message)
 
 


### PR DESCRIPTION
## Summary
- adjust websocket broadcast to send global messages to all active sockets

## Testing
- `pytest -q backend/tests/test_api.py::test_create_material -s`
- `pytest -q` *(fails: TypeError in score_project, pydantic ValidationErrors)*
- `flake8 backend/app/routers/websocket.py`


------
https://chatgpt.com/codex/tasks/task_e_685d63b93428833297fe613601e9cf6e