### PR TITLE
Compute graph layout using levels

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useRef } from 'react'
-import GraphCanvas from './components/GraphCanvas'
+import GraphCanvas, { layoutNodesByLevel } from './components/GraphCanvas'
 import ComponentTable from './components/ComponentTable'
 import useUndoRedo from './components/useUndoRedo'
 import { applyWsMessage, GraphState, WsMessage, Component } from './wsMessage'
@@ -88,15 +88,7 @@ export default function App() {
         if (!isMounted) return
         setState({
           ...data,
-          nodes: data.nodes.map((n: any) => ({
-            ...n,
-            // give each node a deterministic pseudo‑random position so the graph
-            // is immediately visible before users drag nodes around
-            position: {
-              x: Math.random() * 250,
-              y: Math.random() * 250,
-            },
-          })),
+          nodes: layoutNodesByLevel(data.nodes),
         })
 
         // ensure there is at least one material so the “add node” form works

--- a/frontend/src/__tests__/layout.test.ts
+++ b/frontend/src/__tests__/layout.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest'
+import { layoutNodesByLevel, X_OFFSET, Y_SPACING } from '../components/GraphCanvas'
+
+describe('layoutNodesByLevel', () => {
+  it('positions nodes according to level and index', () => {
+    const nodes = [
+      { id: 1, level: 0 },
+      { id: 2, level: 0 },
+      { id: 3, level: 1 },
+      { id: 4, level: 2 },
+    ]
+    const result = layoutNodesByLevel(nodes)
+    expect(result[0].position).toEqual({ x: 0 * X_OFFSET, y: 0 * Y_SPACING })
+    expect(result[1].position).toEqual({ x: 0 * X_OFFSET, y: 1 * Y_SPACING })
+    expect(result[2].position).toEqual({ x: 1 * X_OFFSET, y: 0 * Y_SPACING })
+    expect(result[3].position).toEqual({ x: 2 * X_OFFSET, y: 0 * Y_SPACING })
+  })
+})

--- a/frontend/src/components/GraphCanvas.tsx
+++ b/frontend/src/components/GraphCanvas.tsx
@@ -2,6 +2,23 @@ import React from 'react'
 import ReactFlow, { MiniMap, Controls, Background, Connection } from 'reactflow'
 import 'reactflow/dist/style.css'
 
+/** Fixed spacing for node layout */
+export const X_OFFSET = 250
+export const Y_SPACING = 100
+
+export function layoutNodesByLevel(nodes: any[]) {
+  const counts: Record<number, number> = {}
+  return nodes.map(n => {
+    const level = n.level ?? 0
+    const yIndex = counts[level] ?? 0
+    counts[level] = yIndex + 1
+    return {
+      ...n,
+      position: { x: level * X_OFFSET, y: yIndex * Y_SPACING },
+    }
+  })
+}
+
 
 interface Props {
   nodes: any[]
@@ -10,17 +27,36 @@ interface Props {
 }
 
 export default function GraphCanvas({ nodes, edges, onConnectEdge }: Props) {
+  const laidOut = layoutNodesByLevel(nodes)
+  const maxLevel = Math.max(0, ...nodes.map(n => n.level ?? 0))
+
   return (
-    <ReactFlow
-      nodes={nodes}
-      edges={edges}
-      onConnect={onConnectEdge}
-      fitView
-      style={{ width: '100%', height: '100%' }}
-    >
-      <MiniMap />
-      <Controls />
-      <Background />
-    </ReactFlow>
+    <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+      {Array.from({ length: maxLevel + 1 }).map((_, lvl) => (
+        <div
+          key={lvl}
+          style={{
+            position: 'absolute',
+            left: lvl * X_OFFSET,
+            top: 0,
+            bottom: 0,
+            width: X_OFFSET,
+            borderRight: '1px solid #eee',
+            pointerEvents: 'none',
+          }}
+        />
+      ))}
+      <ReactFlow
+        nodes={laidOut}
+        edges={edges}
+        onConnect={onConnectEdge}
+        fitView
+        style={{ width: '100%', height: '100%' }}
+      >
+        <MiniMap />
+        <Controls />
+        <Background />
+      </ReactFlow>
+    </div>
   )
 }


### PR DESCRIPTION
## Summary
- layout nodes per level and render level lanes
- load initial data using the new layout
- test the layout helper

## Testing
- `npm test`
- `pytest`
- `flake8 ..`

------
https://chatgpt.com/codex/tasks/task_e_685d64ca58e08332be1ffcea6ceeaa05