### PR TITLE
Enable node deletion in UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -285,6 +285,10 @@ export default function App() {
     }).catch((err) => console.error(err))
   }
 
+  const deleteNode = (id: number) => {
+    fetch(`/nodes/${id}`, { method: 'DELETE' }).catch(err => console.error(err))
+  }
+
   /* --------------------------------------------------------------------- */
   /*  9️⃣  Render                                                           */
   /* --------------------------------------------------------------------- */
@@ -443,7 +447,7 @@ export default function App() {
 
       {/* ----------------------------------------------------------------- */}
       <div className="w-1/3 h-full overflow-auto border-l">
-        <ComponentTable components={state.nodes} />
+        <ComponentTable components={state.nodes} onDelete={deleteNode} />
       </div>
     </div>
   )

--- a/frontend/src/__tests__/wsMessage.test.ts
+++ b/frontend/src/__tests__/wsMessage.test.ts
@@ -99,4 +99,11 @@ describe('applyWsMessage', () => {
     expect(typeof result.edges[0].id).toBe('number')
     expect(result.edges[0]).toEqual({ id: 4, source: 1, target: 2 })
   })
+
+  it('removes a node on delete_node', () => {
+    const state: GraphState = { nodes: [{ id: 1 }, { id: 2 }], edges: [], materials: [] }
+    const result = applyWsMessage(state, { op: 'delete_node', id: 1 })
+    expect(result.nodes).toHaveLength(1)
+    expect(result.nodes[0].id).toBe(2)
+  })
 })

--- a/frontend/src/components/ComponentTable.tsx
+++ b/frontend/src/components/ComponentTable.tsx
@@ -9,17 +9,24 @@ import { Component } from '../wsMessage'
 
 interface Props {
   components: Component[]
+  onDelete: (id: number) => void
 }
 
 const columnHelper = createColumnHelper<Component>()
 
-export default function ComponentTable({ components }: Props) {
+export default function ComponentTable({ components, onDelete }: Props) {
   const columns = [
     columnHelper.accessor('name', { header: 'Name' }),
     columnHelper.accessor('level', { header: 'Level' }),
     columnHelper.accessor('weight', { header: 'Weight' }),
     columnHelper.accessor('material_id', { header: 'Material' }),
     columnHelper.accessor('sustainability_score', { header: 'Sustainability' }),
+    columnHelper.display({
+      id: 'delete',
+      cell: info => (
+        <button onClick={() => onDelete(info.row.original.id)}>🗑️</button>
+      ),
+    }),
   ]
 
   const table = useReactTable({


### PR DESCRIPTION
## Summary
- add delete button to ComponentTable
- wire up node delete handler in `App.tsx`
- test reducer `delete_node` handling

## Testing
- `npm test --silent`
- `pytest -q` *(fails: TypeError in `test_score_project`, ValidationError in `test_nodes`)*
- `flake8 ../DIMOP_2.1`

------
https://chatgpt.com/codex/tasks/task_e_685d6589188c8332a22cce2f41d93ce1