### PR TITLE
Add material deletion handler and sidebar table

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useRef } from 'react'
 import GraphCanvas, { layoutNodesByLevel } from './components/GraphCanvas'
 import ComponentTable from './components/ComponentTable'
+import MaterialTable from './components/MaterialTable'
 import useUndoRedo from './components/useUndoRedo'
 import { applyWsMessage, GraphState, WsMessage, Component } from './wsMessage'
 
@@ -289,6 +290,10 @@ export default function App() {
     fetch(`/nodes/${id}`, { method: 'DELETE' }).catch(err => console.error(err))
   }
 
+  const deleteMaterial = (id: number) => {
+    fetch(`/materials/${id}`, { method: 'DELETE' }).catch(err => console.error(err))
+  }
+
   /* --------------------------------------------------------------------- */
   /*  9️⃣  Render                                                           */
   /* --------------------------------------------------------------------- */
@@ -447,6 +452,7 @@ export default function App() {
 
       {/* ----------------------------------------------------------------- */}
       <div className="w-1/3 h-full overflow-auto border-l">
+        <MaterialTable materials={state.materials} onDelete={deleteMaterial} />
         <ComponentTable components={state.nodes} onDelete={deleteNode} />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- allow deleting materials from App
- show MaterialTable in sidebar for current materials

## Testing
- `npm test --silent`
- `npm run lint` *(fails: Missing script)*
- `pytest -q` *(fails: 3 failed tests)*
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686396c9c9c08332a171619b3e414a83