### PR TITLE
Add material deletion handler and sidebar table

### DIFF
--- a/backend/app/routers/score.py
+++ b/backend/app/routers/score.py
@@ -28,7 +28,7 @@ async def score_project(
     )
 
     result = await session.execute(join_stmt)
-    records = [dict(row) for row in result]
+    records = list(result.mappings())
 
     factor_map = {
         ConnectionType.SCREW: 0.8,

--- a/backend/tests/test_nodes.py
+++ b/backend/tests/test_nodes.py
@@ -9,18 +9,52 @@ from app.models.schemas import NodeCreate
 
 
 def test_level_zero_no_parent_ok():
-    NodeCreate(project_id=1, material_id=2, level=0)
+    NodeCreate(
+        project_id=1,
+        material_id=2,
+        level=0,
+        name="x",
+        atomic=False,
+        reusable=False,
+        recyclable=False,
+    )
 
 
 def test_level_zero_with_parent_fails():
     with pytest.raises(ValidationError):
-        NodeCreate(project_id=1, material_id=2, level=0, parent_id=1)
+        NodeCreate(
+            project_id=1,
+            material_id=2,
+            level=0,
+            parent_id=1,
+            name="x",
+            atomic=False,
+            reusable=False,
+            recyclable=False,
+        )
 
 
 def test_level_gt_zero_missing_parent_fails():
     with pytest.raises(ValidationError):
-        NodeCreate(project_id=1, material_id=2, level=1)
+        NodeCreate(
+            project_id=1,
+            material_id=2,
+            level=1,
+            name="x",
+            atomic=False,
+            reusable=False,
+            recyclable=False,
+        )
 
 
 def test_level_gt_zero_with_parent_ok():
-    NodeCreate(project_id=1, material_id=2, level=1, parent_id=1)
+    NodeCreate(
+        project_id=1,
+        material_id=2,
+        level=1,
+        parent_id=1,
+        name="x",
+        atomic=False,
+        reusable=False,
+        recyclable=False,
+    )

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useRef } from 'react'
 import GraphCanvas, { layoutNodesByLevel } from './components/GraphCanvas'
 import ComponentTable from './components/ComponentTable'
+import MaterialTable from './components/MaterialTable'
 import useUndoRedo from './components/useUndoRedo'
 import { applyWsMessage, GraphState, WsMessage, Component } from './wsMessage'
 
@@ -289,6 +290,10 @@ export default function App() {
     fetch(`/nodes/${id}`, { method: 'DELETE' }).catch(err => console.error(err))
   }
 
+  const deleteMaterial = (id: number) => {
+    fetch(`/materials/${id}`, { method: 'DELETE' }).catch(err => console.error(err))
+  }
+
   /* --------------------------------------------------------------------- */
   /*  9️⃣  Render                                                           */
   /* --------------------------------------------------------------------- */
@@ -447,6 +452,7 @@ export default function App() {
 
       {/* ----------------------------------------------------------------- */}
       <div className="w-1/3 h-full overflow-auto border-l">
+        <MaterialTable materials={state.materials} onDelete={deleteMaterial} />
         <ComponentTable components={state.nodes} onDelete={deleteNode} />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- allow deleting materials from App
- show MaterialTable in sidebar for current materials
- fix score endpoint row mapping
- update NodeCreate tests for required fields

## Testing
- `npm test --silent`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686396c9c9c08332a171619b3e414a83