### PR TITLE
Sync canvas separators with viewport

### DIFF
--- a/frontend/src/components/GraphCanvas.tsx
+++ b/frontend/src/components/GraphCanvas.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import ReactFlow, { MiniMap, Controls, Background, Connection } from 'reactflow'
+import ReactFlow, { MiniMap, Controls, Background, Connection, useStore } from 'reactflow'
 import 'reactflow/dist/style.css'
 
 /** Fixed spacing for node layout */
@@ -44,27 +44,40 @@ interface Props {
 }
 
 export default function GraphCanvas({ nodes, edges, onConnectEdge }: Props) {
+  const transform = useStore(state => state.transform)
   const laidOut = adaptNodes(nodes)
   const adaptedEdges = adaptEdges(edges)
   const maxLevel = Math.max(0, ...nodes.map(n => n.level ?? 0))
 
   return (
     <div style={{ position: 'relative', width: '100%', height: '100%' }}>
-      {Array.from({ length: maxLevel + 1 }).map((_, lvl) => (
-        <div
-          key={lvl}
-          style={{
-            position: 'absolute',
-            left: lvl * X_OFFSET,
-            top: 0,
-            bottom: 0,
-            width: X_OFFSET,
-            borderRight: '1px dashed #ccc',
-            borderLeft: lvl === 0 ? '1px dashed #ccc' : undefined,
-            pointerEvents: 'none',
-          }}
-        />
-      ))}
+      <div
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          transform: `translate(${transform[0]}px, ${transform[1]}px) scale(${transform[2]})`,
+          transformOrigin: '0 0',
+          pointerEvents: 'none',
+        }}
+      >
+        {Array.from({ length: maxLevel + 1 }).map((_, lvl) => (
+          <div
+            key={lvl}
+            style={{
+              position: 'absolute',
+              left: lvl * X_OFFSET,
+              top: 0,
+              bottom: 0,
+              width: X_OFFSET,
+              borderRight: '1px dashed #ccc',
+              borderLeft: lvl === 0 ? '1px dashed #ccc' : undefined,
+            }}
+          />
+        ))}
+      </div>
       <ReactFlow
         nodes={laidOut}
         edges={adaptedEdges}


### PR DESCRIPTION
## Summary
- sync GraphCanvas separators with zoom/pan transform

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68639e43d1d48332893d6b53345754b5