### PR TITLE
Improve parent selection logic

### DIFF
--- a/frontend/src/__tests__/filterParentCandidates.test.ts
+++ b/frontend/src/__tests__/filterParentCandidates.test.ts
@@ -16,4 +16,9 @@ describe('filterParentCandidates', () => {
     const nodes: Component[] = [{ id: 1 }, { id: 2, level: 1 }]
     expect(filterParentCandidates(nodes, 1)).toEqual([{ id: 1 }])
   })
+
+  it('returns empty array for level 0', () => {
+    const nodes: Component[] = [{ id: 1, level: 0 }]
+    expect(filterParentCandidates(nodes, 0)).toEqual([])
+  })
 })


### PR DESCRIPTION
## Summary
- use `filterParentCandidates` when opening the create-node form
- recalc parent candidates when the level changes
- update parent/level selection logic
- test `filterParentCandidates` for level 0 case

## Testing
- `npm run test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68639f04e5e883328160577a53835135